### PR TITLE
Create script for scaffolding components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
-  "name": "psikai-component-lib",
-  "version": "1.0.0",
+  "name": "pk-components",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "psikai-component-lib",
-      "version": "1.0.0",
+      "name": "pk-components",
+      "version": "0.1.1",
+      "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.9.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.1",
         "@types/jest": "^29.5.13",
+        "@types/node": "^22.5.5",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react-swc": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "component": "node scripts/component-creation.js"
   },
   "files": [
     "dist"
@@ -40,6 +41,7 @@
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",
     "@types/jest": "^29.5.13",
+    "@types/node": "^22.5.5",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react-swc": "^3.5.0",

--- a/scripts/component-creation.js
+++ b/scripts/component-creation.js
@@ -1,0 +1,118 @@
+import path, { dirname } from "path"
+import fs from "fs"
+import { fileURLToPath } from "url"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+async function main(componentName) {
+  const santizedComponentName = componentName
+    .split(/[-_\s]/g)
+    .map(word => {
+      return word.charAt(0).toUpperCase() + word.slice(1)
+    })
+    .join("")
+
+  const destinationPath = path.join(__dirname, "../src", "components", santizedComponentName)
+
+  if (fs.existsSync(destinationPath)) {
+    console.error("ERROR\nCOMPONENT ALREADY EXISTS:", santizedComponentName)
+    process.exit(1)
+  }
+
+  console.log("CREATING COMPONENT:", santizedComponentName)
+  console.log("DESTINATION PATH:", destinationPath)
+
+  // Create the directory
+  await fs.promises.mkdir(destinationPath, { recursive: true })
+
+  // Create the index.ts file
+  await fs.promises.writeFile(
+    getFullFilePath(destinationPath, "index.ts"),
+    generateIndexFile(santizedComponentName),
+  )
+
+  // Create the component file
+  await fs.promises.writeFile(
+    getFullFilePath(destinationPath, `${santizedComponentName}.tsx`),
+    generateComponentFile(santizedComponentName),
+  )
+
+  // Create the model file
+  await fs.promises.writeFile(
+    getFullFilePath(destinationPath, `${santizedComponentName}.model.ts`),
+    generateModelFile(santizedComponentName),
+  )
+
+  // Create the css file
+  await fs.promises.writeFile(getFullFilePath(destinationPath, `${santizedComponentName}.css`), "")
+
+  // Create the component spec file
+  await fs.promises.writeFile(
+    getFullFilePath(destinationPath, `${santizedComponentName}.spec.tsx`),
+    generateSpecFile(santizedComponentName),
+  )
+
+  console.log("COMPONENT CREATED SUCCESSFULLY")
+}
+
+function getFullFilePath(fullPath, fileName) {
+  return path.join(fullPath, fileName)
+}
+
+/**
+ * FILE TEMPLATE STRING GENERATORS
+ */
+
+function generateIndexFile(componentName) {
+  return `export { ${componentName} } from "./${componentName}"
+`
+}
+
+function generateComponentFile(componentName) {
+  return `import { T${componentName}Props } from "./${componentName}.model"
+import "./${componentName}.css"
+
+export function ${componentName}(props: T${componentName}Props) {
+  return <div>${componentName}</div>
+}
+`
+}
+
+function generateModelFile(componentName) {
+  return `export type T${componentName}Props = {
+  className?: string
+  children?: React.ReactNode
+}
+`
+}
+
+function generateSpecFile(componentName) {
+  return `import React from "react"
+  import { render, screen } from "@testing-library/react"
+  import "@testing-library/jest-dom"
+
+  import { ${componentName} } from "./${componentName}"
+
+  describe("${componentName}", () => {
+    render(<${componentName} />)
+    const component = screen.getByText("${componentName}")
+
+    it("should render the component", () => {
+      expect(component).toBeInTheDocument()
+    })
+  })
+`
+}
+
+/**
+ * END OF FILE TEMPLATE STRING GENERATORS
+ */
+
+const componentName = process.argv[2]
+if (!componentName) {
+  console.error("ERROR: Please provide a component name")
+  process.exit(1)
+}
+
+main(componentName).catch(console.error)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,15 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "types": ["node", "vitest/globals"],
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "types": [
+      "node",
+      "vitest/globals"
+    ],
     "module": "ESNext",
     "skipLibCheck": true,
     "declaration": true,
@@ -24,6 +31,14 @@
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["./src"],
-  "exclude": ["node_modules", "./src/AppDev.tsx", "**/*.test.*", "**/*.spec.*", "./tests"]
+  "include": [
+    "./src"
+  ],
+  "exclude": [
+    "node_modules",
+    "./src/AppDev.tsx",
+    "**/*.test.*",
+    "**/*.spec.*",
+    "./tests"
+  ]
 }


### PR DESCRIPTION
New npm script to add all the module files needed for creating a new component.

Invoke with:

```sh
npm run component <componentname>
```

This will create a directory at `src/components/` level named after the component name passed.

Module files include:
- `index.ts` (main export of module)
- `<componentname>.tsx` (main component file)
- `<componentname>.model.ts` (type definitions)
- `<componentname>.spec.tsx` (test file)
- `<componentname>.css` (styles)

All files are given scaffolding by default and should pass their initial render test in the spec file.

#### Handled Error Cases

- Duplicate component names will be ignored
- A best-effort is made to coerce the component name into PascalCase if another casing convention is supplied