### PR TITLE
Add E2E testing

### DIFF
--- a/.github/workflows/main-build-test.yml
+++ b/.github/workflows/main-build-test.yml
@@ -43,9 +43,15 @@ jobs:
       - name: Execute library build script
         run: npm run build:lib
 
+  TestDemoBuild:
+    needs:
+      - PreviewBuild
+      - RunVitest
+    if: success()
+    uses: ./.github/workflows/preview-build-test.yml
+
   Deploy:
     needs:
-      - RunVitest
-      - PreviewBuild
+      - TestDemoBuild
     if: success()
     uses: ./.github/workflows/gh-pages-deploy.yml

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -51,8 +51,5 @@ jobs:
         run: npm run build:demo
 
   TestDemoBuild:
-    needs:
-      - PreviewBuild
-      - RunVitest
     if: success()
     uses: ./.github/workflows/preview-build-test.yml

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -49,3 +49,10 @@ jobs:
 
       - name: Execute demo build script
         run: npm run build:demo
+
+  TestDemoBuild:
+    needs:
+      - PreviewBuild
+      - RunVitest
+    if: success()
+    uses: ./.github/workflows/preview-build-test.yml

--- a/.github/workflows/preview-build-test.yml
+++ b/.github/workflows/preview-build-test.yml
@@ -22,3 +22,5 @@ jobs:
 
       - name: Run Playwright
         run: npx playwright test
+        env:
+          HOME: /root

--- a/.github/workflows/preview-build-test.yml
+++ b/.github/workflows/preview-build-test.yml
@@ -1,0 +1,24 @@
+name: Test Demo Build
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  TestPreviewDemo:
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.47.2-jammy
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+
+      - name: Setup local packages
+        run: npm install
+
+      - name: Run Playwright
+        run: npx playwright test

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ coverage/
 
 # Local Builds
 pk-components-*.tgz
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/e2e/smoke-test.spec.ts
+++ b/e2e/smoke-test.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "@playwright/test"
+
+test("Renders main header", async ({ page }) => {
+  await page.goto("/")
+
+  await expect(page.getByRole("heading", { name: "PK Component Library" })).toBeVisible()
+})
+
+test("Renders component sections", async ({ page }) => {
+  await page.goto("/")
+
+  for (const component of ["Button", "LoadingSpinner"]) {
+    await expect(page.getByRole("heading", { name: component })).toBeVisible()
+  }
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "pk-components",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pk-components",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.9.0",
+        "@playwright/test": "^1.47.2",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.1",
@@ -1234,6 +1235,21 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.47.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.2.tgz",
+      "integrity": "sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.47.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -5212,6 +5228,50 @@
         "confbox": "^0.1.7",
         "mlly": "^1.7.1",
         "pathe": "^1.1.2"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.47.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.2.tgz",
+      "integrity": "sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.47.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.47.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.2.tgz",
+      "integrity": "sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
+    "@playwright/test": "^1.47.2",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig, devices } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: "html",
+  use: {
+    baseURL: "http://127.0.0.1:3000",
+    trace: "retain-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+
+    {
+      name: "Mobile Chrome",
+      use: { ...devices["Pixel 5"] },
+    },
+    {
+      name: "Mobile Safari",
+      use: { ...devices["iPhone 12"] },
+    },
+  ],
+
+  webServer: {
+    command: "npm run preview",
+    url: "http://127.0.0.1:3000",
+    reuseExistingServer: !process.env.CI,
+  },
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   reporter: "html",
   use: {
-    baseURL: "http://127.0.0.1:3000",
+    baseURL: process.env["BASE_URL"] || "http://127.0.0.1:3000",
     trace: "retain-on-failure",
   },
 

--- a/server.js
+++ b/server.js
@@ -6,7 +6,8 @@ const app = express()
 const __filename = new URL(import.meta.url).pathname
 const __dirname = path.dirname(__filename)
 
-app.use(express.static(__dirname + "/build"))
+app.use(express.static(path.join(__dirname, "build")))
+app.use("/pk-components", express.static(path.join(__dirname, "build")))
 
 app.get("*", (_req, res) => {
   res.sendFile(__dirname + "/build/index.html")

--- a/src/dev/AppDev.tsx
+++ b/src/dev/AppDev.tsx
@@ -8,7 +8,9 @@ export const AppDev = () => {
     <>
       <h1>PK Component Library</h1>
       <ButtonSection />
-      <h2>Loading Spinner</h2>
+      <h2>
+        <code>LoadingSpinner</code>
+      </h2>
       <section>
         <LoadingSpinner />
       </section>

--- a/src/dev/demos/Buttons.tsx
+++ b/src/dev/demos/Buttons.tsx
@@ -27,7 +27,9 @@ function usePending() {
 export const ButtonSection = () => {
   return (
     <>
-      <h2>Button</h2>
+      <h2>
+        <code>Button</code>
+      </h2>
       <h3>Size</h3>
       <ButtonSizes />
       <h3>Variant</h3>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, mergeConfig } from "vitest/config"
+import { defineConfig, mergeConfig, configDefaults } from "vitest/config"
 import viteConfig from "./vite.config"
 
 export default defineConfig(configEnv => {
@@ -14,6 +14,7 @@ export default defineConfig(configEnv => {
           include: ["src/**/*", "utils/**/*"],
           exclude: ["src/dev/**/*"],
         },
+        exclude: [...configDefaults.exclude, "e2e"],
       },
     }),
   )


### PR DESCRIPTION
After updating the base of the demo build, the static assets for the build preview server needed explicit handling for the `/pk-components/` path in the asset requests.

Includes some e2e testing workflows with playwright in order to prevent the same regression.
- New workflow for CI/CD
- Initial smoke test of preview build
- @playwright-test dev-dependency added