### PR TITLE
Fix component creation script

### DIFF
--- a/scripts/component-creation/component-creation.spec.js
+++ b/scripts/component-creation/component-creation.spec.js
@@ -8,10 +8,19 @@ import {
   generateSpecFile,
   generateReadmeFile,
 } from "./component-creation-templates"
+import { findFile } from "../../utils/file-utils"
 
 describe("component-creation", () => {
   const componentName = "TestComponent"
-  const filePath = path.join(__dirname, "../../src", "lib", "components", componentName)
+  const actualComponent = "Button"
+  const expectedHomeDirectory = "src"
+
+  let filePath = findFile(`${actualComponent}.tsx`, expectedHomeDirectory)
+  if (!filePath) {
+    throw new Error(`File not found: ${actualComponent}.tsx`)
+  }
+
+  filePath = path.dirname(filePath).replace(actualComponent, componentName)
 
   beforeAll(() => {
     execSync(`npm run component ${componentName}`)

--- a/scripts/component-creation/component-creation.spec.js
+++ b/scripts/component-creation/component-creation.spec.js
@@ -11,13 +11,13 @@ import {
 
 describe("component-creation", () => {
   const componentName = "TestComponent"
-  const filePath = path.join(__dirname, `../../src/components/${componentName}`)
+  const filePath = path.join(__dirname, "../../src", "lib", "components", componentName)
 
-  beforeEach(() => {
+  beforeAll(() => {
     execSync(`npm run component ${componentName}`)
   })
 
-  afterEach(() => {
+  afterAll(() => {
     if (fs.existsSync(filePath)) {
       fs.rmdirSync(filePath, { recursive: true })
     }

--- a/scripts/component-creation/index.js
+++ b/scripts/component-creation/index.js
@@ -16,7 +16,13 @@ const __dirname = dirname(__filename)
 async function main(componentName) {
   const santizedComponentName = pascalize(componentName)
 
-  const destinationPath = path.join(__dirname, "../../src", "components", santizedComponentName)
+  const destinationPath = path.join(
+    __dirname,
+    "../../src",
+    "lib",
+    "components",
+    santizedComponentName,
+  )
 
   if (fs.existsSync(destinationPath)) {
     console.error("ERROR\nCOMPONENT ALREADY EXISTS:", santizedComponentName)

--- a/utils/file-utils.js
+++ b/utils/file-utils.js
@@ -1,0 +1,27 @@
+import fs from "fs"
+import path from "path"
+
+export function findFile(fileName, dir) {
+  let files
+  try {
+    files = fs.readdirSync(dir)
+  } catch (error) {
+    return null
+  }
+
+  for (let file of files) {
+    const filePath = path.join(dir, file)
+    const stat = fs.statSync(filePath)
+
+    if (stat.isDirectory()) {
+      const found = findFile(fileName, filePath)
+      if (found) {
+        return found
+      }
+    } else if (file === fileName) {
+      return filePath
+    }
+  }
+
+  return null
+}

--- a/utils/file-utils.spec.js
+++ b/utils/file-utils.spec.js
@@ -1,0 +1,39 @@
+import path from "path"
+import fs from "fs"
+import { findFile } from "./file-utils"
+
+describe("findFile", () => {
+  const mockComponent = "Button"
+  const mockPathParts = ["foo", "bar", "lib", "components", mockComponent]
+  const mockPath = path.join(...mockPathParts)
+  const mockFile = `${mockComponent}.tsx`
+  const fullMockPath = path.join(mockPath, mockFile)
+  const subDir = path.join(mockPath, "subdir")
+  const fileInSubDir = path.join(subDir, "SubButton.tsx")
+
+  beforeAll(() => {
+    fs.mkdirSync(mockPath, { recursive: true })
+    fs.writeFileSync(fullMockPath, "")
+    fs.writeFileSync(path.join(...mockPathParts.slice(0, 2), "Random.tsx"), "")
+    fs.mkdirSync(subDir, { recursive: true })
+    fs.writeFileSync(fileInSubDir, "")
+  })
+
+  afterAll(async () => {
+    if (fs.existsSync(mockPathParts[0])) {
+      await fs.promises.rm(mockPathParts[0], { recursive: true })
+    }
+  })
+
+  it("should find the file", () => {
+    expect(findFile("Button.tsx", mockPathParts[0])).toBe(fullMockPath)
+  })
+
+  it("should return null if the file is not found", () => {
+    expect(findFile("NotFound.tsx", mockPathParts[0])).toBe(null)
+  })
+
+  it("should return null if the directory is not found", () => {
+    expect(findFile("Button.tsx", "not-found")).toBe(null)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig(configEnv => {
         coverage: {
           provider: "istanbul",
           include: ["src/**/*", "utils/**/*"],
-          exclude: ["src/dev/**/*"],
+          exclude: ["src/dev/**/*", "**/*.spec.*", "**/*.test.*"],
         },
         exclude: [...configDefaults.exclude, "e2e"],
       },


### PR DESCRIPTION
The script to scaffold all the new component files fell out of sync when some lib files got moved around.  This updates the script file path.

The tests for the creation script were also updated to look for the source of truth when comparing file paths, instead of relying on the same hard-coded path values.