### PR TITLE
Develop `Input` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ npm i pk-components
 
 - [Button](https://github.com/psikai/pk-components/blob/main/src/lib/components/Button/README.md)
 - [LoadingSpinner](https://github.com/psikai/pk-components/blob/main/src/lib/components/LoadingSpinner/README.md)
+- [Input](https://github.com/psikai/pk-components/blob/main/src/lib/components/Input/README.md)
 
 ### Demo
 

--- a/e2e/smoke-test.spec.ts
+++ b/e2e/smoke-test.spec.ts
@@ -10,6 +10,6 @@ test("Renders component sections", async ({ page }) => {
   await page.goto("/")
 
   for (const component of ["Button", "LoadingSpinner", "Input"]) {
-    await expect(page.getByRole("heading", { name: component })).toBeVisible()
+    await expect(page.getByRole("heading", { name: component, exact: true })).toBeVisible()
   }
 })

--- a/e2e/smoke-test.spec.ts
+++ b/e2e/smoke-test.spec.ts
@@ -9,7 +9,7 @@ test("Renders main header", async ({ page }) => {
 test("Renders component sections", async ({ page }) => {
   await page.goto("/")
 
-  for (const component of ["Button", "LoadingSpinner"]) {
+  for (const component of ["Button", "LoadingSpinner", "Input"]) {
     await expect(page.getByRole("heading", { name: component })).toBeVisible()
   }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pk-components",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pk-components",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.9.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "component",
     "library"
   ],
-  "version": "0.3.2",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite --open --port 3001",

--- a/scripts/component-creation/__snapshots__/component-creation.spec.js.snap
+++ b/scripts/component-creation/__snapshots__/component-creation.spec.js.snap
@@ -51,6 +51,8 @@ function YourComponent() {
   return <TestComponent>Your content here</TestComponent>
 }
 \`\`\`
+
+[Live Demo](https://psikai.github.io/pk-components#TestComponent)
 "
 `;
 

--- a/scripts/component-creation/component-creation-templates.js
+++ b/scripts/component-creation/component-creation-templates.js
@@ -69,5 +69,7 @@ function YourComponent() {
   return <${componentName}>Your content here</${componentName}>
 }
 \`\`\`
+
+[Live Demo](https://psikai.github.io/pk-components#${componentName})
 `
 }

--- a/src/dev/AppDev.tsx
+++ b/src/dev/AppDev.tsx
@@ -8,14 +8,17 @@ export const AppDev = () => {
   return (
     <>
       <h1>PK Component Library</h1>
+      <h2 id="Button">
+        <code>Button</code>
+      </h2>
       <ButtonSection />
-      <h2>
+      <h2 id="LoadingSpinner">
         <code>LoadingSpinner</code>
       </h2>
       <section>
         <LoadingSpinner />
       </section>
-      <h2>
+      <h2 id="Input">
         <code>Input</code>
       </h2>
       <section>

--- a/src/dev/AppDev.tsx
+++ b/src/dev/AppDev.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { LoadingSpinner } from "../lib/components/LoadingSpinner"
 import { ButtonSection } from "./demos/Buttons"
 import "./index.css"
+import { InputSection } from "./demos/Inputs"
 
 export const AppDev = () => {
   return (
@@ -13,6 +14,12 @@ export const AppDev = () => {
       </h2>
       <section>
         <LoadingSpinner />
+      </section>
+      <h2>
+        <code>Input</code>
+      </h2>
+      <section>
+        <InputSection />
       </section>
     </>
   )

--- a/src/dev/demos/Buttons.tsx
+++ b/src/dev/demos/Buttons.tsx
@@ -48,7 +48,7 @@ const ButtonSizes = () => {
   return (
     <section>
       {buttonSizes.map(fit => {
-        const props = fit === "link" ? { href: "/" } : { onClick: handleClick }
+        const props = fit === "link" ? { href: "#" } : { onClick: handleClick }
         return (
           <Button key={fit} fit={fit} {...props} pending={pending === fit + "-fit"}>
             {fit + "-fit"}

--- a/src/dev/demos/Buttons.tsx
+++ b/src/dev/demos/Buttons.tsx
@@ -27,9 +27,6 @@ function usePending() {
 export const ButtonSection = () => {
   return (
     <>
-      <h2>
-        <code>Button</code>
-      </h2>
       <h3>Size</h3>
       <ButtonSizes />
       <h3>Variant</h3>

--- a/src/dev/demos/Inputs.tsx
+++ b/src/dev/demos/Inputs.tsx
@@ -45,6 +45,7 @@ export const InputSection = () => {
         value={form.firstName}
         placeholder="John/Jane"
         disabled={pending}
+        required
       />
       <Input
         label="Middle Name"
@@ -68,6 +69,7 @@ export const InputSection = () => {
         value={form.lastName}
         placeholder="Doe"
         disabled={pending}
+        required
       />
 
       <Button

--- a/src/dev/demos/Inputs.tsx
+++ b/src/dev/demos/Inputs.tsx
@@ -32,19 +32,60 @@ export const InputSection = () => {
       <hr />
       <div className="sub-section">
         <h3>Required</h3>
-        <Input id="error-message-text-input" label="Name" feedback="Required" required />
+        <Input
+          id="error-message-text-input"
+          label="Name"
+          hint="Mark the input required for automatic demarcation."
+          feedback="No special characters allowed."
+          required
+        />
       </div>
       <hr />
       <div className="sub-section">
         <h3>With Error Feedback</h3>
-        <Input id="error-text-input" label="Name" error={true} required />
-        <Input id="error-message-text-input" label="Name" error="Invalid name" required />
+        <Input
+          id="error-input"
+          label="No Feedback Text"
+          hint="Pass an empty string for no feedback text"
+          error=""
+        />
+        <Input
+          id="error-text-input"
+          label="Default Feedback Text"
+          hint="Pass a boolean value to get the default feedback text"
+          error
+          required
+        />
+        <Input
+          id="error-message-text-input"
+          label="Custom Feedback Text"
+          hint="Pass a string value to get a custom feedback text"
+          error="Invalid name"
+          required
+        />
       </div>
       <hr />
       <div className="sub-section">
         <h3>With Success Feedback</h3>
-        <Input id="clean-text-input" label="Name" clean />
-        <Input id="clean-message-text-input" label="Name" clean="Name is valid" />
+        <Input
+          id="clean-input"
+          label="No feedback text"
+          hint="Pass an empty string for no feedback text"
+          clean=""
+        />
+        <Input
+          id="clean-text-input"
+          label="Default Feedback Text"
+          hint="Pass a boolean value to get the default feedback text"
+          clean
+        />
+
+        <Input
+          id="clean-message-text-input"
+          label="Custom Feedback Text"
+          hint="Pass a string value to get a custom feedback text"
+          clean="Name is valid"
+        />
       </div>
       <hr />
       <div className="sub-section">
@@ -54,7 +95,7 @@ export const InputSection = () => {
       <hr />
       <div className="sub-section">
         <h3>Disabled</h3>
-        <Input id="disabled-text-input" label="Name" disabled />
+        <Input id="disabled-text-input" label="Name" disabled value="Alexander" />
       </div>
       <hr />
       <div className="sub-section">

--- a/src/dev/demos/Inputs.tsx
+++ b/src/dev/demos/Inputs.tsx
@@ -1,0 +1,82 @@
+import React from "react"
+import { Input } from "../../lib/components/Input"
+import { Button } from "../../lib/components/Button"
+
+export const InputSection = () => {
+  const [form, setForm] = React.useState({ firstName: "", lastName: "", middleName: "" })
+  const [pending, setPending] = React.useState(false)
+  const [touched, setTouched] = React.useState({
+    firstName: false,
+    lastName: false,
+    middleName: false,
+  })
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+    setTouched({ ...touched, [e.target.name]: true })
+  }
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setPending(true)
+    await new Promise(resolve => setTimeout(resolve, 1000))
+    setForm({ firstName: "", lastName: "", middleName: "" })
+    setTouched({ firstName: false, lastName: false, middleName: false })
+    setPending(false)
+    alert(`Hello, ${form.firstName} ${form.lastName}!`)
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      style={{ width: "100%", display: "flex", flexDirection: "column", gap: "1.5rem" }}
+    >
+      <h3>Who are you?</h3>
+      <Input
+        label="First Name"
+        id="firstName"
+        name="firstName"
+        hint="Just your first name"
+        feedback="Required"
+        clean={!!form.firstName}
+        error={touched.firstName && !form.firstName && "This field is required."}
+        onChange={handleChange}
+        value={form.firstName}
+        placeholder="John/Jane"
+        disabled={pending}
+      />
+      <Input
+        label="Middle Name"
+        id="middleName"
+        name="middleName"
+        feedback="Optional"
+        onChange={handleChange}
+        value={form.middleName}
+        placeholder="Middle"
+        disabled={pending}
+      />
+      <Input
+        label="Last Name"
+        id="lastName"
+        name="lastName"
+        hint="Legal name"
+        feedback="Required"
+        clean={!!form.lastName}
+        error={touched.lastName && !form.lastName}
+        onChange={handleChange}
+        value={form.lastName}
+        placeholder="Doe"
+        disabled={pending}
+      />
+
+      <Button
+        type="submit"
+        fit="block"
+        pending={pending}
+        disabled={!form.firstName || !form.lastName}
+      >
+        Submit Name
+      </Button>
+    </form>
+  )
+}

--- a/src/dev/demos/Inputs.tsx
+++ b/src/dev/demos/Inputs.tsx
@@ -3,6 +3,71 @@ import { Input } from "../../lib/components/Input"
 import { Button } from "../../lib/components/Button"
 
 export const InputSection = () => {
+  return (
+    <>
+      <div className="sub-section">
+        <h3>Basic Text Input</h3>
+        <Input id="basic-text-input" />
+      </div>
+      <hr />
+      <div className="sub-section">
+        <h3>With Label</h3>
+        <Input label="Name" id="label-text-input" />
+      </div>
+      <hr />
+      <div className="sub-section">
+        <h3>With Hint Text</h3>
+        <Input id="hint-text-input" label="Name" hint="Enter your name" />
+      </div>
+      <hr />
+      <div className="sub-section">
+        <h3>With Feedback Text</h3>
+        <Input
+          id="feedback-text-input"
+          label="Name"
+          hint="Enter your name"
+          feedback="No special characters allowed."
+        />
+      </div>
+      <hr />
+      <div className="sub-section">
+        <h3>Required</h3>
+        <Input id="error-message-text-input" label="Name" feedback="Required" required />
+      </div>
+      <hr />
+      <div className="sub-section">
+        <h3>With Error Feedback</h3>
+        <Input id="error-text-input" label="Name" error={true} required />
+        <Input id="error-message-text-input" label="Name" error="Invalid name" required />
+      </div>
+      <hr />
+      <div className="sub-section">
+        <h3>With Success Feedback</h3>
+        <Input id="clean-text-input" label="Name" clean />
+        <Input id="clean-message-text-input" label="Name" clean="Name is valid" />
+      </div>
+      <hr />
+      <div className="sub-section">
+        <h3>With Placeholder</h3>
+        <Input id="placeholder-text-input" label="Name" placeholder="John Doe" />
+      </div>
+      <hr />
+      <div className="sub-section">
+        <h3>Disabled</h3>
+        <Input id="disabled-text-input" label="Name" disabled />
+      </div>
+      <hr />
+      <div className="sub-section">
+        <h3>Read Only</h3>
+        <Input id="readonly-text-input" label="Name" value="John Doe" readOnly />
+      </div>
+      <hr />
+      <InputForm />
+    </>
+  )
+}
+
+function InputForm() {
   const [form, setForm] = React.useState({ firstName: "", lastName: "", middleName: "" })
   const [pending, setPending] = React.useState(false)
   const [touched, setTouched] = React.useState({
@@ -32,7 +97,7 @@ export const InputSection = () => {
       onSubmit={handleSubmit}
       style={{ width: "100%", display: "flex", flexDirection: "column", gap: "1.5rem" }}
     >
-      <h3>Who are you?</h3>
+      <h3>With Form Feedback</h3>
       <Input
         label="First Name"
         id="firstName"

--- a/src/dev/demos/Inputs.tsx
+++ b/src/dev/demos/Inputs.tsx
@@ -20,10 +20,11 @@ export const InputSection = () => {
     e.preventDefault()
     setPending(true)
     await new Promise(resolve => setTimeout(resolve, 1000))
+    const name = `${form.firstName} ${form.middleName} ${form.lastName}`
     setForm({ firstName: "", lastName: "", middleName: "" })
     setTouched({ firstName: false, lastName: false, middleName: false })
     setPending(false)
-    alert(`Hello, ${form.firstName} ${form.lastName}!`)
+    alert(`Hello, ${name}!`)
   }
 
   return (

--- a/src/dev/index.css
+++ b/src/dev/index.css
@@ -64,12 +64,34 @@ section {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
 }
 
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
     background-color: #ffffff;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    padding: 0.5rem;
+  }
+
+  h1 {
+    font-size: 2.4em;
+  }
+
+  h2 {
+    font-size: 1.8em;
+  }
+
+  h3 {
+    font-size: 1.2em;
+  }
+
+  section {
+    padding: 1rem;
   }
 }

--- a/src/dev/index.css
+++ b/src/dev/index.css
@@ -21,6 +21,7 @@
 
 body {
   margin: 0;
+  padding: 1rem;
   display: flex;
   justify-content: center;
   min-width: 320px;
@@ -32,6 +33,20 @@ h1 {
   line-height: 1.1;
 }
 
+h2 {
+  font-size: 2.4em;
+  line-height: 1.2;
+}
+
+h3 {
+  font-size: 1.4em;
+  line-height: 1.3;
+}
+
+hr {
+  width: 100%;
+}
+
 section {
   display: flex;
   flex-wrap: wrap;
@@ -41,8 +56,15 @@ section {
   padding: 2rem;
   border-radius: 0.375rem;
   border: 1px solid currentColor;
-  max-width: 600px;
+  max-width: 800px;
   position: relative;
+}
+
+.sub-section {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 @media (prefers-color-scheme: light) {

--- a/src/lib/components/Button/Button.css
+++ b/src/lib/components/Button/Button.css
@@ -1,10 +1,7 @@
+@import "../index.css";
+
 .pk-button {
-  --hue-primary: 200;
-  --hue-secondary: 0;
-  --hue-warning: 30;
-  --hue-danger: 0;
-  --hue-success: 120;
-  --hue: 200;
+  --hue: var(--pk-hue-primary);
   --lightness: 40%;
   --saturation: 100%;
   --color-lightness: 100%;
@@ -107,12 +104,12 @@
 }
 
 .pk-button-primary {
-  --hue: 200;
+  --hue: var(--pk-hue-primary);
 }
 
 .pk-button-warning {
   --lightness: 50%;
-  --hue: 30;
+  --hue: var(--pk-hue-warning);
 
   &:hover:not(:disabled) {
     --lightness: 40%;
@@ -120,12 +117,12 @@
 }
 
 .pk-button-danger {
-  --hue: 0;
+  --hue: var(--pk-hue-danger);
 }
 
 .pk-button-success {
   --lightness: 30%;
-  --hue: 120;
+  --hue: var(--pk-hue-success);
 
   &:hover:not(:disabled) {
     --lightness: 25%;
@@ -135,7 +132,7 @@
 .pk-button-secondary {
   --lightness: 50%;
   --saturation: 0%;
-  --hue: 0;
+  --hue: var(--pk-hue-secondary);
 
   &:hover:not(:disabled) {
     --lightness: 35%;

--- a/src/lib/components/Button/README.md
+++ b/src/lib/components/Button/README.md
@@ -37,3 +37,5 @@ function YourComponent() {
   )
 }
 ```
+
+[Live Demo](https://psikai.github.io/pk-components#Button)

--- a/src/lib/components/Input/Input.css
+++ b/src/lib/components/Input/Input.css
@@ -22,13 +22,23 @@
   border: 0.1em solid currentColor;
   border-radius: 0.25rem;
   padding: 0.5rem;
-  /* padding: 0 0.2em; */
   width: 100%;
   display: block;
 }
 
+.pk-input[type="text"][disabled] {
+  cursor: not-allowed;
+}
+
 .pk-input[type="text"][required] {
   border-left-width: 0.2em;
+}
+
+.pk-input[type="text"][readonly] {
+  box-shadow: 0px 0px 1px 1px rgba(0, 0, 0, 0.3) inset;
+  border-top: none;
+  border-right: none;
+  border-left: none;
 }
 
 .pk-input[type="text"]:focus {
@@ -56,6 +66,12 @@
 
 .pk-input-label {
   font-weight: bold;
+}
+
+.pk-input-label.label-required::after {
+  content: "*";
+  color: hsl(var(--pk-hue-danger), 100%, 40%);
+  padding-left: 0.25rem;
 }
 
 .pk-input-hint {

--- a/src/lib/components/Input/Input.css
+++ b/src/lib/components/Input/Input.css
@@ -85,7 +85,7 @@
   font-weight: thin;
 }
 
-.pk-input-feedback,
+.pk-input-feedback-default,
 .pk-input-feedback-error,
 .pk-input-feedback-clean {
   font-size: 0.9rem;

--- a/src/lib/components/Input/Input.css
+++ b/src/lib/components/Input/Input.css
@@ -43,11 +43,12 @@
   border-top: none;
   border-right: none;
   border-left: none;
+  background-color: hsl(var(--pk-hue-secondary), 0%, 40%, 0.1);
 }
 
 .pk-input[type="text"]:focus {
   outline-offset: 2px;
-  outline: 2px solid currentColor;
+  outline: 2px solid hsl(var(--hue), var(--saturation), var(--lightness));
 }
 
 .pk-input[type="text"].pk-input-error {

--- a/src/lib/components/Input/Input.css
+++ b/src/lib/components/Input/Input.css
@@ -1,0 +1,62 @@
+.pk-input-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.pk-input,
+.pk-input::placeholder {
+  font: inherit;
+  letter-spacing: inherit;
+  word-spacing: inherit;
+}
+
+.pk-input[type="text"] {
+  border: 1px solid currentColor;
+  border-radius: 0.25rem;
+  padding: 0.5rem;
+  width: 100%;
+  display: block;
+}
+
+.pk-input[type="text"]:focus {
+  outline-offset: 2px;
+  outline: 2px solid gray;
+}
+
+.pk-input[type="text"].pk-input-error {
+  border-color: red;
+  outline-color: red;
+}
+
+.pk-input[type="text"].pk-input-clean {
+  border-color: green;
+  outline-color: green;
+}
+
+.pk-input-label {
+  font-weight: bold;
+}
+
+.pk-input-hint {
+  font-size: 0.9rem;
+  font-weight: thin;
+}
+
+.pk-input-feedback {
+  font-size: 0.9rem;
+  font-style: italic;
+}
+
+.pk-input-feedback-error {
+  color: red;
+  font-size: 0.9rem;
+  font-style: italic;
+}
+
+.pk-input-feedback-clean {
+  color: green;
+  font-size: 0.9rem;
+  font-style: italic;
+}

--- a/src/lib/components/Input/Input.css
+++ b/src/lib/components/Input/Input.css
@@ -68,10 +68,10 @@
   font-weight: bold;
 }
 
-.pk-input-label.label-required::after {
+.pk-input-label.label-required::before {
   content: "*";
   color: hsl(var(--pk-hue-danger), 100%, 40%);
-  padding-left: 0.25rem;
+  padding-right: 0.25rem;
 }
 
 .pk-input-hint {

--- a/src/lib/components/Input/Input.css
+++ b/src/lib/components/Input/Input.css
@@ -1,8 +1,14 @@
+@import "../index.css";
+
 .pk-input-wrapper {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   width: 100%;
+
+  --hue: var(--pk-hue-secondary);
+  --lightness: 40%;
+  --saturation: 0%;
 }
 
 .pk-input,
@@ -13,26 +19,39 @@
 }
 
 .pk-input[type="text"] {
-  border: 1px solid currentColor;
+  border: 0.1em solid currentColor;
   border-radius: 0.25rem;
   padding: 0.5rem;
+  /* padding: 0 0.2em; */
   width: 100%;
   display: block;
 }
 
+.pk-input[type="text"][required] {
+  border-left-width: 0.2em;
+}
+
 .pk-input[type="text"]:focus {
   outline-offset: 2px;
-  outline: 2px solid gray;
+  outline: 2px solid currentColor;
 }
 
 .pk-input[type="text"].pk-input-error {
-  border-color: red;
-  outline-color: red;
+  --hue: var(--pk-hue-danger);
+  --lightness: 40%;
+  --saturation: 100%;
 }
 
 .pk-input[type="text"].pk-input-clean {
-  border-color: green;
-  outline-color: green;
+  --hue: var(--pk-hue-success);
+  --lightness: 30%;
+  --saturation: 100%;
+}
+
+.pk-input[type="text"].pk-input-error,
+.pk-input[type="text"].pk-input-clean {
+  border-color: hsl(var(--hue), var(--saturation), var(--lightness));
+  outline-color: hsl(var(--hue), var(--saturation), var(--lightness));
 }
 
 .pk-input-label {
@@ -44,19 +63,26 @@
   font-weight: thin;
 }
 
-.pk-input-feedback {
+.pk-input-feedback,
+.pk-input-feedback-error,
+.pk-input-feedback-clean {
   font-size: 0.9rem;
   font-style: italic;
 }
 
 .pk-input-feedback-error {
-  color: red;
-  font-size: 0.9rem;
-  font-style: italic;
+  --hue: var(--pk-hue-danger);
+  --lightness: 40%;
+  --saturation: 100%;
 }
 
 .pk-input-feedback-clean {
-  color: green;
-  font-size: 0.9rem;
-  font-style: italic;
+  --hue: var(--pk-hue-success);
+  --lightness: 30%;
+  --saturation: 100%;
+}
+
+.pk-input-feedback-clean,
+.pk-input-feedback-error {
+  color: hsl(var(--hue), var(--saturation), var(--lightness));
 }

--- a/src/lib/components/Input/Input.css
+++ b/src/lib/components/Input/Input.css
@@ -54,13 +54,13 @@
 .pk-input[type="text"].pk-input-error {
   --hue: var(--pk-hue-danger);
   --lightness: 40%;
-  --saturation: 100%;
+  --saturation: 50%;
 }
 
 .pk-input[type="text"].pk-input-clean {
   --hue: var(--pk-hue-success);
   --lightness: 30%;
-  --saturation: 100%;
+  --saturation: 70%;
 }
 
 .pk-input[type="text"].pk-input-error,
@@ -95,13 +95,13 @@
 .pk-input-feedback-error {
   --hue: var(--pk-hue-danger);
   --lightness: 40%;
-  --saturation: 100%;
+  --saturation: 50%;
 }
 
 .pk-input-feedback-clean {
   --hue: var(--pk-hue-success);
   --lightness: 30%;
-  --saturation: 100%;
+  --saturation: 70%;
 }
 
 .pk-input-feedback-clean,

--- a/src/lib/components/Input/Input.css
+++ b/src/lib/components/Input/Input.css
@@ -19,7 +19,10 @@
 }
 
 .pk-input[type="text"] {
-  border: 0.1em solid currentColor;
+  --hue: var(--pk-hue-secondary);
+  --lightness: 50%;
+  --saturation: 0%;
+  border: 0.1em solid;
   border-radius: 0.25rem;
   padding: 0.5rem;
   width: 100%;
@@ -59,7 +62,8 @@
 }
 
 .pk-input[type="text"].pk-input-error,
-.pk-input[type="text"].pk-input-clean {
+.pk-input[type="text"].pk-input-clean,
+.pk-input[type="text"] {
   border-color: hsl(var(--hue), var(--saturation), var(--lightness));
   outline-color: hsl(var(--hue), var(--saturation), var(--lightness));
 }

--- a/src/lib/components/Input/Input.css
+++ b/src/lib/components/Input/Input.css
@@ -31,6 +31,7 @@
 
 .pk-input[type="text"][disabled] {
   cursor: not-allowed;
+  background-color: hsl(var(--pk-hue-secondary), 0%, 40%, 0.3);
 }
 
 .pk-input[type="text"][required] {

--- a/src/lib/components/Input/Input.model.ts
+++ b/src/lib/components/Input/Input.model.ts
@@ -1,12 +1,9 @@
 import { AllHtmlAttributes } from "../../core-types"
 
 export type TInputProps = AllHtmlAttributes<HTMLInputElement> & {
-  hint?: string
-  label?: string
   id: string
-} & TFeedbackProps
-
-export type TFeedbackProps = {
+  label?: string
+  hint?: string
   feedback?: string
   clean?: boolean | string
   error?: boolean | string

--- a/src/lib/components/Input/Input.model.ts
+++ b/src/lib/components/Input/Input.model.ts
@@ -1,9 +1,6 @@
 import { AllHtmlAttributes } from "../../core-types"
 
-export type TInputProps = AllHtmlAttributes & {
-  // className?: string
-  // children?: React.ReactNode
-  // onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+export type TInputProps = AllHtmlAttributes<HTMLInputElement> & {
   hint?: string
   label?: string
   id: string

--- a/src/lib/components/Input/Input.model.ts
+++ b/src/lib/components/Input/Input.model.ts
@@ -1,0 +1,16 @@
+import { AllHtmlAttributes } from "../../core-types"
+
+export type TInputProps = AllHtmlAttributes & {
+  // className?: string
+  // children?: React.ReactNode
+  // onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  hint?: string
+  label?: string
+  id: string
+} & TFeedbackProps
+
+export type TFeedbackProps = {
+  feedback?: string
+  clean?: boolean | string
+  error?: boolean | string
+}

--- a/src/lib/components/Input/Input.spec.tsx
+++ b/src/lib/components/Input/Input.spec.tsx
@@ -53,6 +53,19 @@ describe("Input", () => {
     })
   })
 
+  describe("when required", () => {
+    beforeEach(() => {
+      render(
+        <Input id="test" label="test label" feedback="test feedback" hint="test hint" required />,
+      )
+    })
+
+    it("should render a required label", () => {
+      const labelComponent = screen.getByText("test label")
+      expect(labelComponent).toHaveClass("label-required")
+    })
+  })
+
   describe("with error state as string", () => {
     beforeEach(() => {
       render(

--- a/src/lib/components/Input/Input.spec.tsx
+++ b/src/lib/components/Input/Input.spec.tsx
@@ -53,7 +53,7 @@ describe("Input", () => {
     })
   })
 
-  describe("with error state", () => {
+  describe("with error state as string", () => {
     beforeEach(() => {
       render(
         <Input
@@ -62,6 +62,7 @@ describe("Input", () => {
           feedback="test feedback"
           hint="test hint"
           error="test error"
+          clean="test clean"
         />,
       )
     })
@@ -72,9 +73,146 @@ describe("Input", () => {
       expect(errorComponent).toHaveClass("pk-input-feedback-error")
     })
 
+    it("should not display the feedback text", () => {
+      const feedbackComponent = screen.queryByText("test feedback")
+      expect(feedbackComponent).not.toBeInTheDocument()
+    })
+
+    it("should not display the clean text", () => {
+      const cleanComponent = screen.queryByText("test clean")
+      expect(cleanComponent).not.toBeInTheDocument()
+    })
+
     it("should have feedback state of error", () => {
       const inputComponent = screen.getByRole("textbox")
       expect(inputComponent).toHaveClass("pk-input-error")
+    })
+  })
+
+  describe("with error state as boolean", () => {
+    beforeEach(() => {
+      render(
+        <Input
+          id="test"
+          label="test label"
+          feedback="test feedback"
+          hint="test hint"
+          error={true}
+          clean="test clean"
+        />,
+      )
+    })
+
+    it("should render a default error message", () => {
+      const errorComponent = screen.getByText("✗ Invalid")
+      expect(errorComponent).toBeInTheDocument()
+    })
+
+    it("should have feedback state of error", () => {
+      const inputComponent = screen.getByRole("textbox")
+      expect(inputComponent).toHaveClass("pk-input-error")
+    })
+
+    it("should not display the feedback text", () => {
+      const feedbackComponent = screen.queryByText("test feedback")
+      expect(feedbackComponent).not.toBeInTheDocument()
+    })
+
+    it("should not display the clean text", () => {
+      const cleanComponent = screen.queryByText("test clean")
+      expect(cleanComponent).not.toBeInTheDocument()
+    })
+  })
+
+  describe("with clean state", () => {
+    beforeEach(() => {
+      render(
+        <Input
+          id="test"
+          label="test label"
+          feedback="test feedback"
+          hint="test hint"
+          clean="test clean"
+        />,
+      )
+    })
+
+    it("should render a clean message", () => {
+      const cleanComponent = screen.getByText("test clean")
+      expect(cleanComponent).toBeInTheDocument()
+      expect(cleanComponent).toHaveClass("pk-input-feedback-clean")
+    })
+
+    it("should not display the error text", () => {
+      const errorComponent = screen.queryByText("test error")
+      expect(errorComponent).not.toBeInTheDocument()
+    })
+
+    it("should not display the feedback text", () => {
+      const feedbackComponent = screen.queryByText("test feedback")
+      expect(feedbackComponent).not.toBeInTheDocument()
+    })
+
+    it("should have feedback state of clean", () => {
+      const inputComponent = screen.getByRole("textbox")
+      expect(inputComponent).toHaveClass("pk-input-clean")
+    })
+  })
+
+  describe("with clean state as boolean", () => {
+    beforeEach(() => {
+      render(
+        <Input
+          id="test"
+          label="test label"
+          feedback="test feedback"
+          hint="test hint"
+          clean={true}
+        />,
+      )
+    })
+
+    it("should render a default clean message", () => {
+      const cleanComponent = screen.getByText("✓ Done")
+      expect(cleanComponent).toBeInTheDocument()
+    })
+
+    it("should have feedback state of clean", () => {
+      const inputComponent = screen.getByRole("textbox")
+      expect(inputComponent).toHaveClass("pk-input-clean")
+    })
+
+    it("should not display the error text", () => {
+      const errorComponent = screen.queryByText("test error")
+      const defaultErrorComponent = screen.queryByText("✗ Invalid")
+      expect(errorComponent).not.toBeInTheDocument()
+      expect(defaultErrorComponent).not.toBeInTheDocument()
+    })
+
+    it("should not display the feedback text", () => {
+      const feedbackComponent = screen.queryByText("test feedback")
+      expect(feedbackComponent).not.toBeInTheDocument()
+    })
+  })
+
+  describe("with no feedback state", () => {
+    beforeEach(() => {
+      render(<Input id="test" label="test label" hint="test hint" />)
+    })
+
+    it("should not display the error text", () => {
+      const errorComponent = screen.queryByText("test error")
+      expect(errorComponent).not.toBeInTheDocument()
+    })
+
+    it("should not display the feedback text", () => {
+      const feedbackComponent = screen.queryByText("test feedback")
+      expect(feedbackComponent).not.toBeInTheDocument()
+    })
+
+    it("should not display the clean text", () => {
+      const cleanComponent = screen.queryByText("test clean")
+      expect(cleanComponent).not.toBeInTheDocument()
     })
   })
 })

--- a/src/lib/components/Input/Input.spec.tsx
+++ b/src/lib/components/Input/Input.spec.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+  import { render, screen } from "@testing-library/react"
+  import "@testing-library/jest-dom"
+
+  import { Input } from "./Input"
+
+  describe("Input", () => {
+    beforeEach(() => {
+      render(<Input />)
+    })
+
+    it("should render the component", () => {
+      const component = screen.getByText("Input")
+      expect(component).toBeInTheDocument()
+    })
+  })

--- a/src/lib/components/Input/Input.spec.tsx
+++ b/src/lib/components/Input/Input.spec.tsx
@@ -87,6 +87,11 @@ describe("Input", () => {
       const inputComponent = screen.getByRole("textbox")
       expect(inputComponent).toHaveClass("pk-input-error")
     })
+
+    it("should have aria-invalid attribute", () => {
+      const inputComponent = screen.getByRole("textbox")
+      expect(inputComponent).toHaveAttribute("aria-invalid", "true")
+    })
   })
 
   describe("with error state as boolean", () => {
@@ -121,6 +126,11 @@ describe("Input", () => {
     it("should not display the clean text", () => {
       const cleanComponent = screen.queryByText("test clean")
       expect(cleanComponent).not.toBeInTheDocument()
+    })
+
+    it("should have aria-invalid attribute", () => {
+      const inputComponent = screen.getByRole("textbox")
+      expect(inputComponent).toHaveAttribute("aria-invalid", "true")
     })
   })
 

--- a/src/lib/components/Input/Input.spec.tsx
+++ b/src/lib/components/Input/Input.spec.tsx
@@ -37,7 +37,7 @@ describe("Input", () => {
     it("should render feedback text", () => {
       const hintComponent = screen.getByText("test feedback")
       expect(hintComponent).toBeInTheDocument()
-      expect(hintComponent).toHaveClass("pk-input-feedback")
+      expect(hintComponent).toHaveClass("pk-input-feedback-default")
     })
 
     it("should render hint text", () => {
@@ -99,6 +99,46 @@ describe("Input", () => {
     it("should have feedback state of error", () => {
       const inputComponent = screen.getByRole("textbox")
       expect(inputComponent).toHaveClass("pk-input-error")
+    })
+
+    it("should have aria-invalid attribute", () => {
+      const inputComponent = screen.getByRole("textbox")
+      expect(inputComponent).toHaveAttribute("aria-invalid", "true")
+    })
+  })
+
+  describe("with error state as empty string", () => {
+    beforeEach(() => {
+      render(
+        <Input
+          id="test"
+          label="test label"
+          feedback="test feedback"
+          hint="test hint"
+          error=""
+          clean="test clean"
+        />,
+      )
+    })
+
+    it("should not render a default error message", () => {
+      const errorComponent = screen.queryByText("✗ Invalid")
+      expect(errorComponent).not.toBeInTheDocument()
+    })
+
+    it("should have feedback state of error", () => {
+      const inputComponent = screen.getByRole("textbox")
+      expect(inputComponent).toHaveClass("pk-input-error")
+    })
+
+    it("should not display the feedback text", () => {
+      const feedbackComponent = screen.queryByText("test feedback")
+      expect(feedbackComponent).not.toBeInTheDocument()
+    })
+
+    it("should not display the clean text", () => {
+      const cleanComponent = screen.queryByText("test clean")
+      expect(cleanComponent).not.toBeInTheDocument()
     })
 
     it("should have aria-invalid attribute", () => {
@@ -179,6 +219,36 @@ describe("Input", () => {
     it("should have feedback state of clean", () => {
       const inputComponent = screen.getByRole("textbox")
       expect(inputComponent).toHaveClass("pk-input-clean")
+    })
+  })
+
+  describe("with clean state as empty string", () => {
+    beforeEach(() => {
+      render(
+        <Input id="test" label="test label" feedback="test feedback" hint="test hint" clean="" />,
+      )
+    })
+
+    it("should not render a default clean message", () => {
+      const cleanComponent = screen.queryByText("✓ Done")
+      expect(cleanComponent).not.toBeInTheDocument()
+    })
+
+    it("should have feedback state of clean", () => {
+      const inputComponent = screen.getByRole("textbox")
+      expect(inputComponent).toHaveClass("pk-input-clean")
+    })
+
+    it("should not display the error text", () => {
+      const errorComponent = screen.queryByText("test error")
+      const defaultErrorComponent = screen.queryByText("✗ Invalid")
+      expect(errorComponent).not.toBeInTheDocument()
+      expect(defaultErrorComponent).not.toBeInTheDocument()
+    })
+
+    it("should not display the feedback text", () => {
+      const feedbackComponent = screen.queryByText("test feedback")
+      expect(feedbackComponent).not.toBeInTheDocument()
     })
   })
 

--- a/src/lib/components/Input/Input.spec.tsx
+++ b/src/lib/components/Input/Input.spec.tsx
@@ -1,16 +1,80 @@
 import React from "react"
-  import { render, screen } from "@testing-library/react"
-  import "@testing-library/jest-dom"
+import { fireEvent, render, screen } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import { Input } from "./Input"
+import { vi } from "vitest"
 
-  import { Input } from "./Input"
+describe("Input", () => {
+  describe("with initial state", () => {
+    const onChange = vi.fn()
 
-  describe("Input", () => {
     beforeEach(() => {
-      render(<Input />)
+      render(
+        <Input
+          id="test"
+          onChange={onChange}
+          label="test label"
+          feedback="test feedback"
+          hint="test hint"
+          className="test-class"
+          name="test"
+        />,
+      )
     })
 
-    it("should render the component", () => {
-      const component = screen.getByText("Input")
-      expect(component).toBeInTheDocument()
+    it("should render an input", () => {
+      const inputComponent = screen.getByRole("textbox")
+      expect(inputComponent).toBeInTheDocument()
+      expect(inputComponent).toHaveClass("pk-input")
+      expect(inputComponent).toHaveClass("test-class")
+    })
+
+    it("should render an attached label", () => {
+      const labelComponent = screen.getByLabelText("test label")
+      expect(labelComponent).toBeInTheDocument()
+    })
+
+    it("should render feedback text", () => {
+      const hintComponent = screen.getByText("test feedback")
+      expect(hintComponent).toBeInTheDocument()
+      expect(hintComponent).toHaveClass("pk-input-feedback")
+    })
+
+    it("should render hint text", () => {
+      const hintComponent = screen.getByText("test hint")
+      expect(hintComponent).toBeInTheDocument()
+      expect(hintComponent).toHaveClass("pk-input-hint")
+    })
+
+    it("should call the onChange function", () => {
+      const inputComponent = screen.getByRole("textbox")
+      fireEvent.change(inputComponent, { target: { value: "t" } })
+      expect(onChange).toHaveBeenCalled()
     })
   })
+
+  describe("with error state", () => {
+    beforeEach(() => {
+      render(
+        <Input
+          id="test"
+          label="test label"
+          feedback="test feedback"
+          hint="test hint"
+          error="test error"
+        />,
+      )
+    })
+
+    it("should render an error message", () => {
+      const errorComponent = screen.getByText("test error")
+      expect(errorComponent).toBeInTheDocument()
+      expect(errorComponent).toHaveClass("pk-input-feedback-error")
+    })
+
+    it("should have feedback state of error", () => {
+      const inputComponent = screen.getByRole("textbox")
+      expect(inputComponent).toHaveClass("pk-input-error")
+    })
+  })
+})

--- a/src/lib/components/Input/Input.tsx
+++ b/src/lib/components/Input/Input.tsx
@@ -16,7 +16,7 @@ export function Input(props: TInputProps) {
         {label}
       </label>
       <span className="pk-input-hint">{hint}</span>
-      <input type="text" className={`pk-input ${feedbackState} ${className}`} {...rest} />
+      <input id={id} type="text" className={`pk-input ${feedbackState} ${className}`} {...rest} />
       <Feedback error={error} clean={clean} feedback={feedback} />
     </div>
   )

--- a/src/lib/components/Input/Input.tsx
+++ b/src/lib/components/Input/Input.tsx
@@ -3,7 +3,8 @@ import { TInputProps } from "./Input.model"
 import "./Input.css"
 
 export function Input(props: TInputProps) {
-  const { className = "", label, id, hint, feedback, clean, error, ...rest } = props
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { className = "", label, id, hint, feedback, clean, error, type: _type, ...rest } = props
 
   const isError = useMemo(() => error || typeof error === "string", [error])
   const isClean = useMemo(() => clean || typeof clean === "string", [clean])

--- a/src/lib/components/Input/Input.tsx
+++ b/src/lib/components/Input/Input.tsx
@@ -1,23 +1,45 @@
 import { useMemo } from "react"
-import { TFeedbackProps, TInputProps } from "./Input.model"
+import { TInputProps } from "./Input.model"
 import "./Input.css"
 
 export function Input(props: TInputProps) {
   const { className = "", label, id, hint, feedback, clean, error, ...rest } = props
 
+  const isError = useMemo(() => error || typeof error === "string", [error])
+  const isClean = useMemo(() => clean || typeof clean === "string", [clean])
+
   const feedbackState = useMemo(
-    () =>
-      error || typeof error === "string"
-        ? "pk-input-error"
-        : clean || typeof clean === "string"
-          ? "pk-input-clean"
-          : "",
-    [error, clean],
+    () => (isError ? "error" : isClean ? "clean" : "default"),
+    [isError, isClean],
   )
+
+  const feedbackText = useMemo(() => {
+    if (isError) {
+      return typeof error === "string" ? error : "✗ Invalid"
+    }
+    if (isClean) {
+      return typeof clean === "string" ? clean : "✓ Done"
+    }
+    return feedback || ""
+  }, [isError, isClean, error, clean, feedback])
+
+  const inputClassNames = useMemo(() => {
+    return `pk-input pk-input-${feedbackState} ${className}`
+  }, [feedbackState, className])
+
+  const feedbackClassName = useMemo(() => {
+    return `pk-input-feedback-${feedbackState}`
+  }, [feedbackState])
+
+  const ariaInvalid = useMemo(() => (isError ? { "aria-invalid": true } : {}), [isError])
+
+  const labelClassNames = useMemo(() => {
+    return `pk-input-label ${props.required ? "label-required" : ""}`
+  }, [props.required])
 
   return (
     <div className="pk-input-wrapper">
-      <label className={`pk-input-label ${props.required && "label-required"}`} htmlFor={id}>
+      <label className={labelClassNames} htmlFor={id}>
         {label}
       </label>
       <span id={`${id}-hint`} className="pk-input-hint">
@@ -27,27 +49,13 @@ export function Input(props: TInputProps) {
         id={id}
         aria-describedby={`${id}-hint ${id}-feedback`}
         type="text"
-        className={`pk-input ${feedbackState} ${className}`}
-        {...(error ? { "aria-invalid": true } : {})}
+        className={inputClassNames}
+        {...ariaInvalid}
         {...rest}
       />
-      <Feedback error={error} clean={clean} feedback={feedback} id={id} />
+      <span id={`${id}-feedback`} className={feedbackClassName}>
+        {feedbackText}
+      </span>
     </div>
   )
-}
-
-function Feedback({ error, clean, feedback, id }: TFeedbackProps & { id: string }) {
-  return error ? (
-    <span id={`${id}-feedback`} className="pk-input-feedback-error">
-      {typeof error === "string" ? error : "✗ Invalid"}
-    </span>
-  ) : clean ? (
-    <span id={`${id}-feedback`} className="pk-input-feedback-clean">
-      {typeof clean === "string" ? clean : "✓ Done"}
-    </span>
-  ) : feedback ? (
-    <span id={`${id}-feedback`} className="pk-input-feedback">
-      {feedback}
-    </span>
-  ) : null
 }

--- a/src/lib/components/Input/Input.tsx
+++ b/src/lib/components/Input/Input.tsx
@@ -6,7 +6,12 @@ export function Input(props: TInputProps) {
   const { className = "", label, id, hint, feedback, clean, error, ...rest } = props
 
   const feedbackState = useMemo(
-    () => (error ? "pk-input-error" : clean ? "pk-input-clean" : ""),
+    () =>
+      error || typeof error === "string"
+        ? "pk-input-error"
+        : clean || typeof clean === "string"
+          ? "pk-input-clean"
+          : "",
     [error, clean],
   )
 

--- a/src/lib/components/Input/Input.tsx
+++ b/src/lib/components/Input/Input.tsx
@@ -3,7 +3,7 @@ import { TFeedbackProps, TInputProps } from "./Input.model"
 import "./Input.css"
 
 export function Input(props: TInputProps) {
-  const { className, label, id, hint, feedback, clean, error, ...rest } = props
+  const { className = "", label, id, hint, feedback, clean, error, ...rest } = props
 
   const feedbackState = useMemo(
     () => (error ? "pk-input-error" : clean ? "pk-input-clean" : ""),

--- a/src/lib/components/Input/Input.tsx
+++ b/src/lib/components/Input/Input.tsx
@@ -1,0 +1,35 @@
+import { useMemo } from "react"
+import { TFeedbackProps, TInputProps } from "./Input.model"
+import "./Input.css"
+
+export function Input(props: TInputProps) {
+  const { className, label, id, hint, feedback, clean, error, ...rest } = props
+
+  const feedbackState = useMemo(
+    () => (error ? "pk-input-error" : clean ? "pk-input-clean" : ""),
+    [error, clean],
+  )
+
+  return (
+    <div className="pk-input-wrapper">
+      <label className="pk-input-label" htmlFor={id}>
+        {label}
+      </label>
+      <span className="pk-input-hint">{hint}</span>
+      <input type="text" className={`pk-input ${feedbackState} ${className}`} {...rest} />
+      <Feedback error={error} clean={clean} feedback={feedback} />
+    </div>
+  )
+}
+
+function Feedback({ error, clean, feedback }: TFeedbackProps) {
+  return error ? (
+    <span className="pk-input-feedback-error">
+      {typeof error === "string" ? error : "✗ Invalid"}
+    </span>
+  ) : clean ? (
+    <span className="pk-input-feedback-clean">{typeof clean === "string" ? clean : "✓ Done"}</span>
+  ) : feedback ? (
+    <span className="pk-input-feedback">{feedback}</span>
+  ) : null
+}

--- a/src/lib/components/Input/Input.tsx
+++ b/src/lib/components/Input/Input.tsx
@@ -12,7 +12,7 @@ export function Input(props: TInputProps) {
 
   return (
     <div className="pk-input-wrapper">
-      <label className="pk-input-label" htmlFor={id}>
+      <label className={`pk-input-label ${props.required && "label-required"}`} htmlFor={id}>
         {label}
       </label>
       <span id={`${id}-hint`} className="pk-input-hint">

--- a/src/lib/components/Input/Input.tsx
+++ b/src/lib/components/Input/Input.tsx
@@ -15,21 +15,33 @@ export function Input(props: TInputProps) {
       <label className="pk-input-label" htmlFor={id}>
         {label}
       </label>
-      <span className="pk-input-hint">{hint}</span>
-      <input id={id} type="text" className={`pk-input ${feedbackState} ${className}`} {...rest} />
-      <Feedback error={error} clean={clean} feedback={feedback} />
+      <span id={`${id}-hint`} className="pk-input-hint">
+        {hint}
+      </span>
+      <input
+        id={id}
+        aria-describedby={`${id}-hint ${id}-feedback`}
+        type="text"
+        className={`pk-input ${feedbackState} ${className}`}
+        {...rest}
+      />
+      <Feedback error={error} clean={clean} feedback={feedback} id={id} />
     </div>
   )
 }
 
-function Feedback({ error, clean, feedback }: TFeedbackProps) {
+function Feedback({ error, clean, feedback, id }: TFeedbackProps & { id: string }) {
   return error ? (
-    <span className="pk-input-feedback-error">
+    <span id={`${id}-feedback`} className="pk-input-feedback-error">
       {typeof error === "string" ? error : "✗ Invalid"}
     </span>
   ) : clean ? (
-    <span className="pk-input-feedback-clean">{typeof clean === "string" ? clean : "✓ Done"}</span>
+    <span id={`${id}-feedback`} className="pk-input-feedback-clean">
+      {typeof clean === "string" ? clean : "✓ Done"}
+    </span>
   ) : feedback ? (
-    <span className="pk-input-feedback">{feedback}</span>
+    <span id={`${id}-feedback`} className="pk-input-feedback">
+      {feedback}
+    </span>
   ) : null
 }

--- a/src/lib/components/Input/Input.tsx
+++ b/src/lib/components/Input/Input.tsx
@@ -23,6 +23,7 @@ export function Input(props: TInputProps) {
         aria-describedby={`${id}-hint ${id}-feedback`}
         type="text"
         className={`pk-input ${feedbackState} ${className}`}
+        {...(error ? { "aria-invalid": true } : {})}
         {...rest}
       />
       <Feedback error={error} clean={clean} feedback={feedback} id={id} />

--- a/src/lib/components/Input/README.md
+++ b/src/lib/components/Input/README.md
@@ -1,0 +1,24 @@
+### Input Component
+
+#### Description
+
+A brief description of the component. Basic functionality and behavior.
+
+#### Props
+
+| Prop Name            | Type                                                                | Required | Default       | Description                                     |
+| -------------------- | ------------------------------------------------------------------- | -------- | ------------- | ----------------------------------------------- |
+| `[htmlAttributes]` | `React.AllHTMLAttributes<HTMLElement>`                            | No       | `undefined` | Any valid HTML attribute for the element type   |
+| `aria-*`          | `[key: aria-${string}]: string \| number \| boolean \| null` | No       | `undefined` | Optional Accessibility attributes               |
+| `data-*`          | `[key: data-${string}]: string \| number \| boolean \| null` | No       | `undefined` | Optional dataset attributes                     |
+| `className`        | `string`                                                          | No       | `undefined` | Additional class names to apply to the spinner. |
+
+#### Example
+
+```tsx
+import { Input } from "pk-components"
+
+function YourComponent() {
+  return <Input>Your content here</Input>
+}
+```

--- a/src/lib/components/Input/README.md
+++ b/src/lib/components/Input/README.md
@@ -2,16 +2,41 @@
 
 #### Description
 
-A brief description of the component. Basic functionality and behavior.
+A text input based component. Complete with accessible label, hint, and feedback text. Styled with color coordinated custom feedback states, and indications for required, disabled, and readonly native states. All html attributes accepted by an input element can be passed through, allowing for granular control over the input behavior and validation.
+
+#### States
+
+- Default
+- Clean
+- Error
+
+Default state shows the `feedback` text, if any, and shows no additional styles on the element.
+
+A clean state is shown if the `clean` prop has a string or true boolean value. A boolean true value will render the default text, while a string will override this. Pass an empty string to trigger the clean state styles with no feedback text. The default feedback text will not display.
+
+An error state is shown if the `error` props has a string or true boolean values. A boolean true value will render the default text, while a string will override this. Pass an empty string to trigger the error state styles with no feedback text. Neither the default feedback text or the clean feedback text will display.
+
+- Required
+
+A red asterisk is prepended to the label text as the main indicator, but the input itself has an increased left border as further demarcation.
+
+- Read Only
+- Disabled
+
+Both given muted styles to indicate a lack of interactivity.
 
 #### Props
 
-| Prop Name            | Type                                                                | Required | Default       | Description                                     |
-| -------------------- | ------------------------------------------------------------------- | -------- | ------------- | ----------------------------------------------- |
-| `[htmlAttributes]` | `React.AllHTMLAttributes<HTMLElement>`                            | No       | `undefined` | Any valid HTML attribute for the element type   |
-| `aria-*`          | `[key: aria-${string}]: string \| number \| boolean \| null` | No       | `undefined` | Optional Accessibility attributes               |
-| `data-*`          | `[key: data-${string}]: string \| number \| boolean \| null` | No       | `undefined` | Optional dataset attributes                     |
-| `className`        | `string`                                                          | No       | `undefined` | Additional class names to apply to the spinner. |
+| Prop Name          | Type                                    | Required | Default     | Description                                                                                  |
+| ------------------ | --------------------------------------- | -------- | ----------- | -------------------------------------------------------------------------------------------- |
+| `[htmlAttributes]` | `React.AllHTMLAttributes<InputElement>` | No       | `undefined` | Any valid HTML attribute for an input element.                                               |
+| `className`        | `string`                                | No       | `undefined` | Additional class names to apply to the spinner.                                              |
+| `id`               | `string`                                | Yes      | `undefined` | Id attribute assiged to input element. Required to create an accessible label.               |
+| `label`            | `string`                                | No       | `undefined` | The accessble label to be associatied with the input. Not required but strongly recommended. |
+| `hint`             | `string`                                | No       | `undefined` | Smaller hint text to go under the label.                                                     |
+| `feedback`         | `string`                                | No       | `undefined` | Custom informative feedback about the input requirements under the element.                  |
+| `error`            | `string \| boolean`                     | No       | `undefined` | Custom or default error feedback under the element.                                          |
+| `clean`            | `string \| boolean`                     | No       | `undefined` | Custom or default success feedback under the element.                                        |
 
 #### Example
 
@@ -19,6 +44,15 @@ A brief description of the component. Basic functionality and behavior.
 import { Input } from "pk-components"
 
 function YourComponent() {
-  return <Input>Your content here</Input>
+  return (
+    <Input
+      id="example-input"
+      label="Your content here"
+      hint="Your customized input"
+      feedback="You'll love this input"
+    />
+  )
 }
 ```
+
+[Live Demo](https://psikai.github.io/pk-components#Input)

--- a/src/lib/components/Input/README.md
+++ b/src/lib/components/Input/README.md
@@ -46,7 +46,7 @@ import { Input } from "pk-components"
 function YourComponent() {
   const [value, setValue] = React.useState("")
 
-  const onChange = (e: React.ChangeEvent) => {
+  const onChange = (e: React.ChangeEvent<InputElement>) => {
     setValue(e.target.value)
   }
 

--- a/src/lib/components/Input/README.md
+++ b/src/lib/components/Input/README.md
@@ -30,8 +30,8 @@ Both given muted styles to indicate a lack of interactivity.
 | Prop Name          | Type                                    | Required | Default     | Description                                                                                  |
 | ------------------ | --------------------------------------- | -------- | ----------- | -------------------------------------------------------------------------------------------- |
 | `[htmlAttributes]` | `React.AllHTMLAttributes<InputElement>` | No       | `undefined` | Any valid HTML attribute for an input element.                                               |
-| `className`        | `string`                                | No       | `undefined` | Additional class names to apply to the spinner.                                              |
-| `id`               | `string`                                | Yes      | `undefined` | Id attribute assiged to input element. Required to create an accessible label.               |
+| `className`        | `string`                                | No       | `undefined` | Additional class names to apply to the input element.                                        |
+| `id`               | `string`                                | Yes      | `undefined` | Id attribute assigned to the input element. Required to create an accessible label.          |
 | `label`            | `string`                                | No       | `undefined` | The accessble label to be associatied with the input. Not required but strongly recommended. |
 | `hint`             | `string`                                | No       | `undefined` | Smaller hint text to go under the label.                                                     |
 | `feedback`         | `string`                                | No       | `undefined` | Custom informative feedback about the input requirements under the element.                  |
@@ -44,12 +44,20 @@ Both given muted styles to indicate a lack of interactivity.
 import { Input } from "pk-components"
 
 function YourComponent() {
+  const [value, setValue] = React.useState("")
+
+  const onChange = (e: React.ChangeEvent) => {
+    setValue(e.target.value)
+  }
+
   return (
     <Input
       id="example-input"
       label="Your content here"
       hint="Your customized input"
       feedback="You'll love this input"
+      onChange={onChange}
+      value={value}
     />
   )
 }

--- a/src/lib/components/Input/index.ts
+++ b/src/lib/components/Input/index.ts
@@ -1,0 +1,2 @@
+export { Input } from "./Input"
+export type { TInputProps } from "./Input.model"

--- a/src/lib/components/LoadingSpinner/README.md
+++ b/src/lib/components/LoadingSpinner/README.md
@@ -30,3 +30,5 @@ function YourComponent() {
   )
 }
 ```
+
+[Live Demo](https://psikai.github.io/pk-components#LoadingSpinner)

--- a/src/lib/components/index.css
+++ b/src/lib/components/index.css
@@ -1,0 +1,7 @@
+:root {
+  --pk-hue-primary: 200;
+  --pk-hue-secondary: 0;
+  --pk-hue-warning: 30;
+  --pk-hue-danger: 0;
+  --pk-hue-success: 120;
+}


### PR DESCRIPTION
Adds a fully customizable text input component.  Only supports `[type="text"]` which is set automatically.

### `Input`

Features:
- label
- hint text
- feedback text
   - standard, success, error
- Disabled, readonly, focus, required states
- Color coordinated feedback for different states
- Accessibility

PR Includes:
- New examples for Input in demo app
   - Pretty exhaustive list but not nearly all the possible combinations
   - Some cleanup of styles overall
- Tests, tests, tests
- Introduction of index.css included in component stylesheets
   - Just the standard colors so far
- Refactors to the Button stylesheet for the new index
- Includes links to live demos in readme documentation
   - Updates component creation script to include readme links