### PR TITLE
Improve demo site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pk-components",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pk-components",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.9.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "component",
     "library"
   ],
-  "version": "0.5.1",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite --open --port 3001",

--- a/src/dev/AppDev.tsx
+++ b/src/dev/AppDev.tsx
@@ -1,9 +1,9 @@
 import React from "react"
-import { LoadingSpinner } from "../lib/components/LoadingSpinner"
 import { InputSection } from "./demos/Inputs"
 import { ButtonSection } from "./demos/Buttons"
 import { FileInputSection } from "./demos/FileInputs"
 import "./index.css"
+import { LoadingSpinnerSection } from "./demos/LoadingSpinners"
 
 export const AppDev = () => {
   return (
@@ -20,7 +20,7 @@ export const AppDev = () => {
           <code>LoadingSpinner</code>
         </h2>
         <section>
-          <LoadingSpinner />
+          <LoadingSpinnerSection />
         </section>
       </div>
       <div className="section-wrapper">

--- a/src/dev/AppDev.tsx
+++ b/src/dev/AppDev.tsx
@@ -2,8 +2,8 @@ import React from "react"
 import { InputSection } from "./demos/Inputs"
 import { ButtonSection } from "./demos/Buttons"
 import { FileInputSection } from "./demos/FileInputs"
-import "./index.css"
 import { LoadingSpinnerSection } from "./demos/LoadingSpinners"
+import "./index.css"
 
 export const AppDev = () => {
   return (

--- a/src/dev/demos/Buttons.tsx
+++ b/src/dev/demos/Buttons.tsx
@@ -48,23 +48,20 @@ const buttonProps = composePropsTableData([
 
 export const ButtonSection = () => {
   return (
-    <>
-      <section>
-        <div className="sub-section">
-          <h3>Props</h3>
-          <PropsTable rows={buttonProps} />
-        </div>
-      </section>
+    <section>
+      <div className="sub-section">
+        <h3>Props</h3>
+        <PropsTable rows={buttonProps} />
+      </div>
 
-      <h3>Size</h3>
       <ButtonSizes />
-      <h3>Variant</h3>
+      <hr />
       <ButtonVariants />
-      <h3>Outline</h3>
+      <hr />
       <ButtonOutline />
-      <h3>State</h3>
+      <hr />
       <ButtonState />
-    </>
+    </section>
   )
 }
 
@@ -72,16 +69,19 @@ const ButtonSizes = () => {
   const { pending, handleClick } = usePending()
 
   return (
-    <section>
-      {buttonSizes.map(fit => {
-        const props = fit === "link" ? { href: "#" } : { onClick: handleClick }
-        return (
-          <Button key={fit} fit={fit} {...props} pending={pending === fit + "-fit"}>
-            {fit + "-fit"}
-          </Button>
-        )
-      })}
-    </section>
+    <div className="sub-section">
+      <h3>Fit</h3>
+      <div className="section-group">
+        {buttonSizes.map(fit => {
+          const props = fit === "link" ? { href: "#" } : { onClick: handleClick }
+          return (
+            <Button key={fit} fit={fit} {...props} pending={pending === fit + "-fit"}>
+              {fit + "-fit"}
+            </Button>
+          )
+        })}
+      </div>
+    </div>
   )
 }
 
@@ -89,18 +89,21 @@ const ButtonVariants = () => {
   const { pending, handleClick } = usePending()
 
   return (
-    <section>
-      {buttonVariants.map(variant => (
-        <Button
-          key={variant}
-          variant={variant}
-          onClick={handleClick}
-          pending={pending === variant + "-variant"}
-        >
-          {variant + "-variant"}
-        </Button>
-      ))}
-    </section>
+    <div className="sub-section">
+      <h3>Variant</h3>
+      <div className="section-group">
+        {buttonVariants.map(variant => (
+          <Button
+            key={variant}
+            variant={variant}
+            onClick={handleClick}
+            pending={pending === variant + "-variant"}
+          >
+            {variant + "-variant"}
+          </Button>
+        ))}
+      </div>
+    </div>
   )
 }
 
@@ -108,19 +111,22 @@ const ButtonOutline = () => {
   const { pending, handleClick } = usePending()
 
   return (
-    <section>
-      {buttonVariants.map(variant => (
-        <Button
-          key={variant}
-          variant={variant}
-          fill="outline"
-          onClick={handleClick}
-          pending={pending === variant + "-outline"}
-        >
-          {variant + "-outline"}
-        </Button>
-      ))}
-    </section>
+    <div className="sub-section">
+      <h3>Outline</h3>
+      <div className="section-group">
+        {buttonVariants.map(variant => (
+          <Button
+            key={variant}
+            variant={variant}
+            fill="outline"
+            onClick={handleClick}
+            pending={pending === variant + "-outline"}
+          >
+            {variant + "-outline"}
+          </Button>
+        ))}
+      </div>
+    </div>
   )
 }
 
@@ -147,10 +153,19 @@ const ButtonState = () => {
 
   return (
     <>
-      <h4>Disabled</h4>
-      <section>{buttonVariants.map(variant => buttonMap(variant, true, false))}</section>
-      <h4>Pending</h4>
-      <section>{buttonVariants.map(variant => buttonMap(variant, false, true))}</section>
+      <div className="sub-section">
+        <h3>State</h3>
+        <h4>Disabled</h4>
+        <div className="section-group">
+          {buttonVariants.map(variant => buttonMap(variant, true, false))}
+        </div>
+      </div>
+      <div className="sub-section">
+        <h4>Pending</h4>
+        <div className="section-group">
+          {buttonVariants.map(variant => buttonMap(variant, false, true))}
+        </div>
+      </div>
     </>
   )
 }

--- a/src/dev/demos/Buttons.tsx
+++ b/src/dev/demos/Buttons.tsx
@@ -28,8 +28,8 @@ function usePending() {
 
 const buttonProps = composePropsTableData([
   [
-    "[HTML Attributes]",
-    "React.AllHTMLAttributes",
+    "[HTML\u00A0Attributes]",
+    "React.AllHTMLAttributes<\n  HTMLButtonElement | \n  HTMLAnchorElement\n>",
     "undefined",
     "Pass-through HTML attributes for button or anchor element.",
   ],
@@ -42,7 +42,7 @@ const buttonProps = composePropsTableData([
   ],
   ["fit", '"small" | "medium" | "large" | "block" | "link"', "large", "Size of the button."],
   ["fill", '"solid" | "outline"', "solid", "Fill style of the button."],
-  ["pending", "boolean", "false", "Disable and how pending state of the button."],
+  ["pending", "boolean", "false", "Disable and show pending state of the button."],
   ["children", "ReactNode", "undefined", "Content inside the button."],
 ])
 
@@ -50,7 +50,7 @@ export const ButtonSection = () => {
   return (
     <section>
       <div className="sub-section">
-        <h3>Props</h3>
+        <h3 className="sub-section-header">Props</h3>
         <PropsTable rows={buttonProps} />
       </div>
 

--- a/src/dev/demos/Buttons.tsx
+++ b/src/dev/demos/Buttons.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback } from "react"
 import type { TButtonProps } from "../../lib/components/Button"
 import { Button } from "../../lib/components/Button"
+import { PropsTable } from "../utils/PropsTable"
+import { composePropsTableData } from "../utils/PropsTable.utils"
 
 const buttonVariants = [
   "primary",
@@ -24,9 +26,36 @@ function usePending() {
   return { pending, handleClick }
 }
 
+const buttonProps = composePropsTableData([
+  [
+    "[HTML Attributes]",
+    "React.AllHTMLAttributes",
+    "undefined",
+    "Pass-through HTML attributes for button or anchor element.",
+  ],
+  ["href", "string", "undefined", "Turns the button into an anchor element and assigns the href."],
+  [
+    "variant",
+    '"primary" | "secondary" | "success" | "warning" | "danger"',
+    "primary",
+    "Color variant of the button.",
+  ],
+  ["fit", '"small" | "medium" | "large" | "block" | "link"', "large", "Size of the button."],
+  ["fill", '"solid" | "outline"', "solid", "Fill style of the button."],
+  ["pending", "boolean", "false", "Disable and how pending state of the button."],
+  ["children", "ReactNode", "undefined", "Content inside the button."],
+])
+
 export const ButtonSection = () => {
   return (
     <>
+      <section>
+        <div className="sub-section">
+          <h3>Props</h3>
+          <PropsTable rows={buttonProps} />
+        </div>
+      </section>
+
       <h3>Size</h3>
       <ButtonSizes />
       <h3>Variant</h3>

--- a/src/dev/demos/FileInputs.tsx
+++ b/src/dev/demos/FileInputs.tsx
@@ -1,5 +1,7 @@
 import React, { useRef } from "react"
 import { FileInput } from "../../lib/components/FileInput"
+import { composePropsTableData } from "../utils/PropsTable.utils"
+import { PropsTable } from "../utils/PropsTable"
 
 export function FileInputSection() {
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -8,23 +10,56 @@ export function FileInputSection() {
     }
   }
 
+  const fileInputProps = composePropsTableData([
+    [
+      "[HTML\u00A0Attributes]",
+      "React.AllHTMLAttributes<\n  HTMLInputElement\n>",
+      "undefined",
+      "Pass-through HTML attributes for input element.",
+    ],
+    ["id", "string", "undefined", "Required unique identifier for the input."],
+    [
+      "label",
+      "string",
+      "undefined",
+      "A description of the input. Not the strict accessible label.",
+    ],
+    ["fileDisplay", '"list" | "preview"', "undefined", "Display type of the inputted files."],
+    [
+      "ref",
+      "React.RefObject<HTMLInputElement>",
+      "undefined",
+      "Forwarded ref for the input element.",
+    ],
+    [
+      "dropzone",
+      "boolean",
+      "false",
+      "Enable the dropzone feature. A ref is required with the dropzone.",
+    ],
+  ])
+
   const fileInput = useRef<HTMLInputElement>(null)
 
   return (
     <>
       <div className="sub-section">
+        <h3 className="sub-section-header">Props</h3>
+        <PropsTable rows={fileInputProps} />
+      </div>
+      <div className="sub-section">
         <h3>With label, hint, and file list</h3>
         <FileInput
           id="file-input-list"
           onChange={onChange}
-          multiple
           label="Upload your résumé"
           fileDisplay="list"
           accept=".jpg,.jpeg,.png,.pdf"
         />
       </div>
+      <hr />
       <div className="sub-section">
-        <h3>With label hint and file preview</h3>
+        <h3>With label, hint, and file preview</h3>
         <FileInput
           id="file-input-preview"
           onChange={onChange}
@@ -35,8 +70,9 @@ export function FileInputSection() {
           required
         />
       </div>
+      <hr />
       <div className="sub-section">
-        <h3 id="Dropzone">With label dropzone</h3>
+        <h3 id="Dropzone">With dropzone area</h3>
         <FileInput
           id="file-input-preview-dropzone"
           onChange={onChange}
@@ -44,7 +80,6 @@ export function FileInputSection() {
           label="Share your vacation photos"
           accept="image/*"
           multiple
-          required
           dropzone
           ref={fileInput}
         />

--- a/src/dev/demos/Inputs.tsx
+++ b/src/dev/demos/Inputs.tsx
@@ -1,10 +1,31 @@
 import React from "react"
 import { Input } from "../../lib/components/Input"
 import { Button } from "../../lib/components/Button"
+import { PropsTable } from "../utils/PropsTable"
+import { composePropsTableData } from "../utils/PropsTable.utils"
+
+const inputProps = composePropsTableData([
+  [
+    "[HTML Attributes]",
+    "React.AllHTMLAttributes",
+    "undefined",
+    "Pass-through HTML attributes for input element",
+  ],
+  ["id", "string", "undefined", "Unique identifier for the input"],
+  ["label", "string", "undefined", "Label for the input"],
+  ["hint", "string", "undefined", "Hint text for the input"],
+  ["feedback", "string", "undefined", "Feedback text for the input"],
+  ["error", "string | boolean", "undefined", "Error feedback text for the input"],
+  ["clean", "string | boolean", "undefined", "Success feedback text for the input"],
+])
 
 export const InputSection = () => {
   return (
     <>
+      <div className="sub-section">
+        <h3>Props</h3>
+        <PropsTable rows={inputProps} />
+      </div>
       <div className="sub-section">
         <h3>Basic Text Input</h3>
         <Input id="basic-text-input" />

--- a/src/dev/demos/Inputs.tsx
+++ b/src/dev/demos/Inputs.tsx
@@ -6,8 +6,8 @@ import { composePropsTableData } from "../utils/PropsTable.utils"
 
 const inputProps = composePropsTableData([
   [
-    "[HTML Attributes]",
-    "React.AllHTMLAttributes",
+    "[HTML\u00A0Attributes]",
+    "React.AllHTMLAttributes<\n  HTMLInputElement\n>",
     "undefined",
     "Pass-through HTML attributes for input element.",
   ],
@@ -23,7 +23,7 @@ export const InputSection = () => {
   return (
     <>
       <div className="sub-section">
-        <h3>Props</h3>
+        <h3 className="sub-section-header">Props</h3>
         <PropsTable rows={inputProps} />
       </div>
       <div className="sub-section">

--- a/src/dev/demos/Inputs.tsx
+++ b/src/dev/demos/Inputs.tsx
@@ -12,11 +12,21 @@ const inputProps = composePropsTableData([
     "Pass-through HTML attributes for input element.",
   ],
   ["id", "string", "undefined", "Required unique identifier for the input."],
-  ["label", "string", "undefined", "Accessible label for the input"],
-  ["hint", "string", "undefined", "Supplemental text for a detailed description."],
-  ["feedback", "string", "undefined", "Feedback text for the state or requirements of the input."],
-  ["error", "string | boolean", "undefined", "Feedback for the error state of the input."],
-  ["clean", "string | boolean", "undefined", "Feedback for the success state of the input."],
+  ["label", "React.ReactNode", "undefined", "Accessible label for the input"],
+  ["hint", "React.ReactNode", "undefined", "Supplemental text for a detailed description."],
+  [
+    "feedback",
+    "React.ReactNode",
+    "undefined",
+    "Feedback text for the state or requirements of the input.",
+  ],
+  ["error", "React.ReactNode | boolean", "undefined", "Feedback for the error state of the input."],
+  [
+    "clean",
+    "React.ReactNode | boolean",
+    "undefined",
+    "Feedback for the success state of the input.",
+  ],
 ])
 
 export const InputSection = () => {

--- a/src/dev/demos/Inputs.tsx
+++ b/src/dev/demos/Inputs.tsx
@@ -9,14 +9,14 @@ const inputProps = composePropsTableData([
     "[HTML Attributes]",
     "React.AllHTMLAttributes",
     "undefined",
-    "Pass-through HTML attributes for input element",
+    "Pass-through HTML attributes for input element.",
   ],
-  ["id", "string", "undefined", "Unique identifier for the input"],
-  ["label", "string", "undefined", "Label for the input"],
-  ["hint", "string", "undefined", "Hint text for the input"],
-  ["feedback", "string", "undefined", "Feedback text for the input"],
-  ["error", "string | boolean", "undefined", "Error feedback text for the input"],
-  ["clean", "string | boolean", "undefined", "Success feedback text for the input"],
+  ["id", "string", "undefined", "Required unique identifier for the input."],
+  ["label", "string", "undefined", "Accessible label for the input"],
+  ["hint", "string", "undefined", "Supplemental text for a detailed description."],
+  ["feedback", "string", "undefined", "Feedback text for the state or requirements of the input."],
+  ["error", "string | boolean", "undefined", "Feedback for the error state of the input."],
+  ["clean", "string | boolean", "undefined", "Feedback for the success state of the input."],
 ])
 
 export const InputSection = () => {

--- a/src/dev/demos/LoadingSpinners.tsx
+++ b/src/dev/demos/LoadingSpinners.tsx
@@ -1,0 +1,118 @@
+import React, { ReactNode, useMemo } from "react"
+import { LoadingSpinner, TLoadingSpinnerProps } from "../../lib/components/LoadingSpinner"
+import { PropsTable } from "../utils/PropsTable"
+import { composePropsTableData } from "../utils/PropsTable.utils"
+import { Input } from "../../lib/components/Input"
+
+const loadingSpinnerProps = composePropsTableData([
+  ["fit", '"xs" | "sm" | "md" | "lg" | "xl"', '"md"', "Size of the spinner."],
+  [
+    "backdrop",
+    "boolean",
+    "true",
+    "Show a backdrop behind the spinner. Backdrop takes up all available space.",
+  ],
+])
+
+const spinnerSizes = ["xs", "sm", "md", "lg", "xl"] as TLoadingSpinnerProps["fit"][]
+
+export function LoadingSpinnerSection() {
+  return (
+    <>
+      <div className="sub-section">
+        <h3 className="sub-section-header">Props</h3>
+        <PropsTable rows={loadingSpinnerProps} />
+      </div>
+      <div className="sub-section">
+        <h3>Basic Spinner</h3>
+        <div className="spinner-container">
+          <p>The spinner and the backdrop overlay the content...</p>
+          <LoadingSpinner />
+        </div>
+      </div>
+      <hr />
+      <div className="sub-section">
+        <h3>Fit Variants</h3>
+        <div className="section-group">
+          {spinnerSizes.map(fit => (
+            <div key={fit} className="spinner-container">
+              <span>{fit}</span>
+              <LoadingSpinner fit={fit} />
+            </div>
+          ))}
+        </div>
+      </div>
+      <hr />
+      <div className="sub-section">
+        <h3>No Backdrop</h3>
+        <div className="spinner-container">
+          <div className="section-group">
+            <p>
+              The spinner is inline with the content <LoadingSpinner backdrop={false} fit="sm" />
+            </p>
+          </div>
+        </div>
+      </div>
+      <hr />
+      <div className="sub-section">
+        <h3>Embedded in components</h3>
+        <SpinnerInInput />
+      </div>
+    </>
+  )
+}
+
+function SpinnerInInput() {
+  const feedbackTypes = useMemo(
+    () => ({
+      invalid: { error: "Username is taken!" },
+      valid: { clean: "Username is available!" },
+      default: { feedback: "Must be unique!" },
+      pending: { feedback: <LoadingSpinner fit="xs" backdrop={false} /> },
+    }),
+    [],
+  )
+
+  const [inputValue, setInputValue] = React.useState("")
+  const [feedbackState, setFeedbackState] = React.useState<Record<string, ReactNode>>(
+    feedbackTypes.default,
+  )
+  const activeTimer = React.useRef<NodeJS.Timeout | null>(null)
+  const activeThrottle = React.useRef<NodeJS.Timeout | null>(null)
+
+  const fakeSearch = React.useCallback(async () => {
+    setFeedbackState(feedbackTypes.pending)
+    await new Promise(resolve => {
+      if (activeTimer.current) clearTimeout(activeTimer.current)
+      activeTimer.current = setTimeout(resolve, 1000)
+    })
+    setFeedbackState(Math.random() > 0.5 ? feedbackTypes.valid : feedbackTypes.invalid)
+  }, [feedbackTypes])
+
+  const onChange = React.useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      setInputValue(e.target.value)
+      if (!e.target.value) {
+        if (activeTimer.current) clearTimeout(activeTimer.current)
+        if (activeThrottle.current) clearTimeout(activeThrottle.current)
+        setFeedbackState(feedbackTypes.default)
+        return
+      }
+
+      if (activeThrottle.current) clearTimeout(activeThrottle.current)
+      activeThrottle.current = setTimeout(fakeSearch, 500)
+      setFeedbackState(feedbackTypes.default)
+    },
+    [feedbackTypes, fakeSearch],
+  )
+
+  return (
+    <Input
+      id="loading-spinner-input"
+      label="Choose your Username"
+      onChange={onChange}
+      value={inputValue}
+      {...feedbackState}
+    />
+  )
+}

--- a/src/dev/index.css
+++ b/src/dev/index.css
@@ -75,6 +75,14 @@ section {
   gap: 1.5rem;
 }
 
+.section-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-evenly;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;

--- a/src/dev/index.css
+++ b/src/dev/index.css
@@ -18,6 +18,8 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  --sticky-header: 3rem;
 }
 
 body {
@@ -25,8 +27,11 @@ body {
   padding: 1rem;
   display: flex;
   justify-content: center;
-  min-width: 320px;
   min-height: 100vh;
+}
+
+#root {
+  width: 100%;
 }
 
 h1 {
@@ -48,11 +53,29 @@ hr {
   width: 100%;
 }
 
-.section-header {
+.section-wrapper {
+  width: 800px;
+  max-width: 100%;
+  margin: 0 auto;
+}
+
+.section-header,
+.sub-section-header {
   position: sticky;
-  top: 0;
-  z-index: 1;
   background-color: var(--background-color);
+  height: var(--sticky-header);
+  display: flex;
+  align-items: center;
+}
+
+.section-header {
+  top: 0;
+  z-index: 2;
+}
+
+.sub-section-header {
+  top: var(--sticky-header);
+  z-index: 1;
 }
 
 section {
@@ -64,8 +87,12 @@ section {
   padding: 2rem;
   border-radius: 0.375rem;
   border: 1px solid currentColor;
-  max-width: 800px;
   position: relative;
+}
+
+code {
+  display: inline-block;
+  white-space: pre-wrap;
 }
 
 .sub-section {
@@ -73,6 +100,7 @@ section {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  position: relative;
 }
 
 .section-group {

--- a/src/dev/index.css
+++ b/src/dev/index.css
@@ -37,6 +37,7 @@ body {
 h1 {
   font-size: 3.2em;
   line-height: 1.1;
+  text-align: center;
 }
 
 h2 {
@@ -109,6 +110,17 @@ code {
   gap: 1rem;
   align-items: center;
   justify-content: space-evenly;
+}
+
+.spinner-container {
+  min-height: 100px;
+  min-width: 100px;
+  position: relative;
+  border-radius: 1rem;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  padding: 0.5rem;
 }
 
 @media (prefers-color-scheme: light) {

--- a/src/dev/utils/PropsTable.css
+++ b/src/dev/utils/PropsTable.css
@@ -1,7 +1,32 @@
-td {
-  padding: 0.5em 0;
+.table-wrapper {
+  overflow-x: scroll;
+  width: 100%;
+}
+
+table {
+  table-layout: fixed;
+  min-width: 700px;
+  border-collapse: collapse;
+  position: relative;
+}
+
+thead {
+  text-align: left;
+}
+
+tr {
   border-bottom: 1px solid currentColor;
-  height: 4em;
+}
+
+td {
+  height: 6em;
+  max-width: 30%;
+  width: min-content;
+  text-wrap: balance;
+}
+
+td:not(:last-child) {
+  padding-right: 1em;
 }
 
 .prop-description {
@@ -11,5 +36,4 @@ td {
 td span {
   display: block;
   font-size: 0.875em;
-  padding-left: 1em;
 }

--- a/src/dev/utils/PropsTable.css
+++ b/src/dev/utils/PropsTable.css
@@ -21,7 +21,7 @@ tr {
 td {
   height: 6em;
   max-width: 30%;
-  width: min-content;
+  width: fit-content;
   text-wrap: balance;
 }
 

--- a/src/dev/utils/PropsTable.css
+++ b/src/dev/utils/PropsTable.css
@@ -1,0 +1,15 @@
+td {
+  padding: 0.5em 0;
+  border-bottom: 1px solid currentColor;
+  height: 4em;
+}
+
+.prop-description {
+  width: 30%;
+}
+
+td span {
+  display: block;
+  font-size: 0.875em;
+  padding-left: 1em;
+}

--- a/src/dev/utils/PropsTable.tsx
+++ b/src/dev/utils/PropsTable.tsx
@@ -7,31 +7,33 @@ type TPropsTableRow = { name: string; type: string; default: string; description
 
 export function PropsTable({ rows }: { rows: TPropsTableRow[] }) {
   return (
-    <table>
-      <thead>
-        <tr>
-          {propsTableHeadings.map((heading, index) => (
-            <th key={index}>{heading}</th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row, index) => (
-          <tr key={index}>
-            {Object.entries(row).map(([attr, cell], jindex) =>
-              attr === "description" ? (
-                <td key={jindex} className="prop-description">
-                  <span>{cell}</span>
-                </td>
-              ) : (
-                <td key={jindex}>
-                  <code>{cell}</code>
-                </td>
-              ),
-            )}
+    <div className="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            {propsTableHeadings.map((heading, index) => (
+              <th key={index}>{heading}</th>
+            ))}
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => (
+            <tr key={index}>
+              {Object.entries(row).map(([attr, cell], jindex) =>
+                attr === "description" ? (
+                  <td key={jindex} className="prop-description">
+                    <span>{cell}</span>
+                  </td>
+                ) : (
+                  <td key={jindex}>
+                    <code>{cell}</code>
+                  </td>
+                ),
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   )
 }

--- a/src/dev/utils/PropsTable.tsx
+++ b/src/dev/utils/PropsTable.tsx
@@ -21,7 +21,7 @@ export function PropsTable({ rows }: { rows: TPropsTableRow[] }) {
             {Object.entries(row).map(([attr, cell], jindex) =>
               attr === "description" ? (
                 <td key={jindex} className="prop-description">
-                  {cell}
+                  <span>{cell}</span>
                 </td>
               ) : (
                 <td key={jindex}>

--- a/src/dev/utils/PropsTable.tsx
+++ b/src/dev/utils/PropsTable.tsx
@@ -1,0 +1,37 @@
+import React from "react"
+import "./PropsTable.css"
+
+const propsTableHeadings = ["Name", "Type", "Default", "Description"]
+
+type TPropsTableRow = { name: string; type: string; default: string; description: string }
+
+export function PropsTable({ rows }: { rows: TPropsTableRow[] }) {
+  return (
+    <table>
+      <thead>
+        <tr>
+          {propsTableHeadings.map((heading, index) => (
+            <th key={index}>{heading}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, index) => (
+          <tr key={index}>
+            {Object.entries(row).map(([attr, cell], jindex) =>
+              attr === "description" ? (
+                <td key={jindex} className="prop-description">
+                  {cell}
+                </td>
+              ) : (
+                <td key={jindex}>
+                  <code>{cell}</code>
+                </td>
+              ),
+            )}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/src/dev/utils/PropsTable.utils.ts
+++ b/src/dev/utils/PropsTable.utils.ts
@@ -1,0 +1,10 @@
+type TRow = [string, string, string, string]
+
+export function composePropsTableData(rows: TRow[]) {
+  return rows.map(row => ({
+    name: row[0],
+    type: row[1],
+    default: row[2],
+    description: row[3],
+  }))
+}

--- a/src/lib/components/Button/Button.model.ts
+++ b/src/lib/components/Button/Button.model.ts
@@ -1,15 +1,9 @@
-import React from "react"
 import { AllHtmlAttributes } from "../../core-types"
 
 export type TButtonProps = AllHtmlAttributes<HTMLButtonElement | HTMLAnchorElement> & {
-  children?: React.ReactNode
-  onClick?: React.MouseEventHandler<HTMLButtonElement>
-  className?: string
-  disabled?: boolean
   type?: "button" | "submit" | "reset"
   variant?: "primary" | "secondary" | "success" | "warning" | "danger"
   fit?: "small" | "medium" | "large" | "block" | "link"
   fill?: "solid" | "outline"
   pending?: boolean
-  href?: string
 }

--- a/src/lib/components/Button/Button.tsx
+++ b/src/lib/components/Button/Button.tsx
@@ -9,7 +9,6 @@ export function Button(props: TButtonProps) {
     children,
     className,
     disabled = false,
-    type = "button",
     variant = "primary",
     fit = "large",
     fill = "solid",
@@ -28,7 +27,7 @@ export function Button(props: TButtonProps) {
       {children}
     </a>
   ) : (
-    <button className={classString} disabled={disabled || pending} type={type} {...rest}>
+    <button className={classString} disabled={disabled || pending} {...rest}>
       {children}
       {pending && <LoadingSpinner fit={spinnerSizeMap[fit]} />}
     </button>

--- a/src/lib/components/Button/README.md
+++ b/src/lib/components/Button/README.md
@@ -12,13 +12,10 @@ A reusable button component that accepts content (`children`), a click event han
 | `aria-*`           | `[key: aria-${string}]: string \| number \| boolean \| null`      | No       | `undefined` | Optional Accessibility attributes                              |
 | `data-*`           | `[key: data-${string}]: string \| number \| boolean \| null`      | No       | `undefined` | Optional dataset attributes                                    |
 | `children`         | `React.ReactNode`                                                 | No       | `undefined` | Content to display inside the button.                          |
-| `onClick`          | `React.MouseEventHandler<HTMLButtonElement>`                      | No       | `undefined` | Function to handle the button's click event.                   |
 | `className`        | `string`                                                          | No       | `undefined` | Additional CSS class for styling the button.                   |
-| `disabled`         | `boolean`                                                         | No       | `false`     | Disables the button from user interaction.                     |
 | `pending`          | `boolean`                                                         | No       | `false`     | Disables the button and presents a loading spinner.            |
 | `variant`          | `"primary" \| "secondary" \| "success" \| "warning" \| "danger"`  | No       | `"primary"` | Determines the style of button to display.                     |
-| `type`             | `"button" \| "submit" \| "reset"`                                 | No       | `"button"`  | Assigns the semantic HTML button type.                         |
-| `size`             | `"small" \| "medium" \| "large" \| "block" \| "link"`             | No       | `"large"`   | Determines the size of the button to display.                  |
+| `fit`              | `"small" \| "medium" \| "large" \| "block" \| "link"`             | No       | `"large"`   | Determines the size of the button to display.                  |
 | `href`             | `string`                                                          | No       | `undefined` | When present, converts the button to an anchor tag.            |
 | `fill`             | `"solid" \| "outline"`                                            | No       | `"solid"`   | Changes the button's background color from filled to outlined. |
 

--- a/src/lib/components/FileInput/FileInput.model.ts
+++ b/src/lib/components/FileInput/FileInput.model.ts
@@ -1,7 +1,8 @@
 import { AllHtmlAttributes } from "../../core-types"
 
-export type TFileInputProps = AllHtmlAttributes & {
+export type TFileInputProps = AllHtmlAttributes<HTMLInputElement> & {
   id: string
+  label: string
   onChange: React.ChangeEventHandler<HTMLInputElement>
   fileDisplay?: "list" | "preview"
   dropzone?: boolean

--- a/src/lib/components/FileInput/FileInput.model.ts
+++ b/src/lib/components/FileInput/FileInput.model.ts
@@ -2,8 +2,8 @@ import { AllHtmlAttributes } from "../../core-types"
 
 export type TFileInputProps = AllHtmlAttributes<HTMLInputElement> & {
   id: string
-  label: string
   onChange: React.ChangeEventHandler<HTMLInputElement>
+  label?: string
   fileDisplay?: "list" | "preview"
   dropzone?: boolean
   ref?: React.RefObject<HTMLInputElement>

--- a/src/lib/components/FileInput/FileInput.spec.tsx
+++ b/src/lib/components/FileInput/FileInput.spec.tsx
@@ -189,7 +189,7 @@ describe("FileInput", () => {
         it("should log the event", () => {
           const dropzone = screen.getByTestId("pk-dropzone")
           const { dataTransfer } = getMockDataEvent(false)
-          const consoleSpy = vi.spyOn(console, "log")
+          const consoleSpy = vi.spyOn(console, "log").mockImplementation(vi.fn())
 
           fireEvent.drop(dropzone, { dataTransfer })
           expect(consoleSpy).toHaveBeenCalled()

--- a/src/lib/components/FileInput/FileInput.tsx
+++ b/src/lib/components/FileInput/FileInput.tsx
@@ -155,7 +155,7 @@ export const FileInput = forwardRef<HTMLInputElement, TFileInputProps>((props, r
       ) : fileDisplay === "preview" ? (
         <div id={`${id}-file-list`} className="pk-file-preview-wrapper">
           {[...filePreview.entries()].map(([fileName, preview]) => (
-            <div className="pk-file-preview">
+            <div className="pk-file-preview" key={fileName}>
               <Button
                 variant="secondary"
                 fit="small"

--- a/src/lib/components/Input/Input.model.ts
+++ b/src/lib/components/Input/Input.model.ts
@@ -2,9 +2,9 @@ import { AllHtmlAttributes } from "../../core-types"
 
 export type TInputProps = AllHtmlAttributes<HTMLInputElement> & {
   id: string
-  label?: string
-  hint?: string
-  feedback?: string
-  clean?: boolean | string
-  error?: boolean | string
+  label?: React.ReactNode
+  hint?: React.ReactNode
+  feedback?: React.ReactNode
+  clean?: boolean | React.ReactNode
+  error?: boolean | React.ReactNode
 }

--- a/src/lib/components/Input/Input.spec.tsx
+++ b/src/lib/components/Input/Input.spec.tsx
@@ -148,42 +148,80 @@ describe("Input", () => {
   })
 
   describe("with error state as boolean", () => {
-    beforeEach(() => {
-      render(
-        <Input
-          id="test"
-          label="test label"
-          feedback="test feedback"
-          hint="test hint"
-          error={true}
-          clean="test clean"
-        />,
-      )
+    describe("when error is true", () => {
+      beforeEach(() => {
+        render(
+          <Input
+            id="test"
+            label="test label"
+            feedback="test feedback"
+            hint="test hint"
+            error={true}
+            clean="test clean"
+          />,
+        )
+      })
+
+      it("should render a default error message", () => {
+        const errorComponent = screen.getByText("✗ Invalid")
+        expect(errorComponent).toBeInTheDocument()
+      })
+
+      it("should have feedback state of error", () => {
+        const inputComponent = screen.getByRole("textbox")
+        expect(inputComponent).toHaveClass("pk-input-error")
+      })
+
+      it("should not display the feedback text", () => {
+        const feedbackComponent = screen.queryByText("test feedback")
+        expect(feedbackComponent).not.toBeInTheDocument()
+      })
+
+      it("should not display the clean text", () => {
+        const cleanComponent = screen.queryByText("test clean")
+        expect(cleanComponent).not.toBeInTheDocument()
+      })
+
+      it("should have aria-invalid attribute", () => {
+        const inputComponent = screen.getByRole("textbox")
+        expect(inputComponent).toHaveAttribute("aria-invalid", "true")
+      })
     })
 
-    it("should render a default error message", () => {
-      const errorComponent = screen.getByText("✗ Invalid")
-      expect(errorComponent).toBeInTheDocument()
-    })
+    describe("when error is false", () => {
+      beforeEach(() => {
+        render(
+          <Input
+            id="test"
+            label="test label"
+            feedback="test feedback"
+            hint="test hint"
+            error={false}
+          />,
+        )
+      })
 
-    it("should have feedback state of error", () => {
-      const inputComponent = screen.getByRole("textbox")
-      expect(inputComponent).toHaveClass("pk-input-error")
-    })
+      it("should not display the error text", () => {
+        const errorComponent = screen.queryByText("test error")
+        const defaultErrorComponent = screen.queryByText("✗ Invalid")
+        expect(errorComponent).not.toBeInTheDocument()
+        expect(defaultErrorComponent).not.toBeInTheDocument()
+      })
 
-    it("should not display the feedback text", () => {
-      const feedbackComponent = screen.queryByText("test feedback")
-      expect(feedbackComponent).not.toBeInTheDocument()
-    })
+      it("should not have feedback state of error", () => {
+        const inputComponent = screen.getByRole("textbox")
+        expect(inputComponent).not.toHaveClass("pk-input-error")
+      })
 
-    it("should not display the clean text", () => {
-      const cleanComponent = screen.queryByText("test clean")
-      expect(cleanComponent).not.toBeInTheDocument()
-    })
+      it("should not have aria-invalid attribute", () => {
+        const inputComponent = screen.getByRole("textbox")
+        expect(inputComponent).not.toHaveAttribute("aria-invalid")
+      })
 
-    it("should have aria-invalid attribute", () => {
-      const inputComponent = screen.getByRole("textbox")
-      expect(inputComponent).toHaveAttribute("aria-invalid", "true")
+      it("should display the feedback text", () => {
+        const feedbackComponent = screen.getByText("test feedback")
+        expect(feedbackComponent).toBeInTheDocument()
+      })
     })
   })
 
@@ -253,38 +291,71 @@ describe("Input", () => {
   })
 
   describe("with clean state as boolean", () => {
-    beforeEach(() => {
-      render(
-        <Input
-          id="test"
-          label="test label"
-          feedback="test feedback"
-          hint="test hint"
-          clean={true}
-        />,
-      )
+    describe("when clean is true", () => {
+      beforeEach(() => {
+        render(
+          <Input
+            id="test"
+            label="test label"
+            feedback="test feedback"
+            hint="test hint"
+            clean={true}
+          />,
+        )
+      })
+
+      it("should render a default clean message", () => {
+        const cleanComponent = screen.getByText("✓ Done")
+        expect(cleanComponent).toBeInTheDocument()
+      })
+
+      it("should have feedback state of clean", () => {
+        const inputComponent = screen.getByRole("textbox")
+        expect(inputComponent).toHaveClass("pk-input-clean")
+      })
+
+      it("should not display the error text", () => {
+        const errorComponent = screen.queryByText("test error")
+        const defaultErrorComponent = screen.queryByText("✗ Invalid")
+        expect(errorComponent).not.toBeInTheDocument()
+        expect(defaultErrorComponent).not.toBeInTheDocument()
+      })
+
+      it("should not display the feedback text", () => {
+        const feedbackComponent = screen.queryByText("test feedback")
+        expect(feedbackComponent).not.toBeInTheDocument()
+      })
     })
 
-    it("should render a default clean message", () => {
-      const cleanComponent = screen.getByText("✓ Done")
-      expect(cleanComponent).toBeInTheDocument()
-    })
+    describe("when clean is false", () => {
+      beforeEach(() => {
+        render(
+          <Input
+            id="test"
+            label="test label"
+            feedback="test feedback"
+            hint="test hint"
+            clean={false}
+          />,
+        )
+      })
 
-    it("should have feedback state of clean", () => {
-      const inputComponent = screen.getByRole("textbox")
-      expect(inputComponent).toHaveClass("pk-input-clean")
-    })
+      it("should not display the clean text", () => {
+        const cleanComponent = screen.queryByText("test clean")
+        const defaultCleanComponent = screen.queryByText("✓ Done")
+        expect(cleanComponent).not.toBeInTheDocument()
+        expect(defaultCleanComponent).not.toBeInTheDocument()
+      })
 
-    it("should not display the error text", () => {
-      const errorComponent = screen.queryByText("test error")
-      const defaultErrorComponent = screen.queryByText("✗ Invalid")
-      expect(errorComponent).not.toBeInTheDocument()
-      expect(defaultErrorComponent).not.toBeInTheDocument()
-    })
+      it("should not have feedback state of clean", () => {
+        const inputComponent = screen.getByRole("textbox")
+        expect(inputComponent).not.toHaveClass("pk-input-clean")
+      })
 
-    it("should not display the feedback text", () => {
-      const feedbackComponent = screen.queryByText("test feedback")
-      expect(feedbackComponent).not.toBeInTheDocument()
+      it("should display the feedback text", () => {
+        const feedbackComponent = screen.getByText("test feedback")
+        expect(feedbackComponent).toBeInTheDocument()
+      })
     })
   })
 

--- a/src/lib/components/Input/Input.spec.tsx
+++ b/src/lib/components/Input/Input.spec.tsx
@@ -225,6 +225,42 @@ describe("Input", () => {
     })
   })
 
+  describe("with error state as undefined", () => {
+    beforeEach(() => {
+      render(
+        <Input
+          id="test"
+          label="test label"
+          feedback="test feedback"
+          hint="test hint"
+          error={undefined}
+        />,
+      )
+    })
+
+    it("should not display the error text", () => {
+      const errorComponent = screen.queryByText("test error")
+      const defaultErrorComponent = screen.queryByText("✗ Invalid")
+      expect(errorComponent).not.toBeInTheDocument()
+      expect(defaultErrorComponent).not.toBeInTheDocument()
+    })
+
+    it("should not have feedback state of error", () => {
+      const inputComponent = screen.getByRole("textbox")
+      expect(inputComponent).not.toHaveClass("pk-input-error")
+    })
+
+    it("should not have aria-invalid attribute", () => {
+      const inputComponent = screen.getByRole("textbox")
+      expect(inputComponent).not.toHaveAttribute("aria-invalid")
+    })
+
+    it("should display the feedback text", () => {
+      const feedbackComponent = screen.getByText("test feedback")
+      expect(feedbackComponent).toBeInTheDocument()
+    })
+  })
+
   describe("with clean state", () => {
     beforeEach(() => {
       render(
@@ -356,6 +392,37 @@ describe("Input", () => {
         const feedbackComponent = screen.getByText("test feedback")
         expect(feedbackComponent).toBeInTheDocument()
       })
+    })
+  })
+
+  describe("with clean state as undefined", () => {
+    beforeEach(() => {
+      render(
+        <Input
+          id="test"
+          label="test label"
+          feedback="test feedback"
+          hint="test hint"
+          clean={undefined}
+        />,
+      )
+    })
+
+    it("should not display the clean text", () => {
+      const cleanComponent = screen.queryByText("test clean")
+      const defaultCleanComponent = screen.queryByText("✓ Done")
+      expect(cleanComponent).not.toBeInTheDocument()
+      expect(defaultCleanComponent).not.toBeInTheDocument()
+    })
+
+    it("should not have feedback state of clean", () => {
+      const inputComponent = screen.getByRole("textbox")
+      expect(inputComponent).not.toHaveClass("pk-input-clean")
+    })
+
+    it("should display the feedback text", () => {
+      const feedbackComponent = screen.getByText("test feedback")
+      expect(feedbackComponent).toBeInTheDocument()
     })
   })
 

--- a/src/lib/components/Input/Input.tsx
+++ b/src/lib/components/Input/Input.tsx
@@ -16,10 +16,10 @@ export function Input(props: TInputProps) {
 
   const feedbackText = useMemo(() => {
     if (isError) {
-      return typeof error === "string" ? error : "✗ Invalid"
+      return error === true ? "✗ Invalid" : error
     }
     if (isClean) {
-      return typeof clean === "string" ? clean : "✓ Done"
+      return clean === true ? "✓ Done" : clean
     }
     return feedback || ""
   }, [isError, isClean, error, clean, feedback])

--- a/src/lib/components/Input/README.md
+++ b/src/lib/components/Input/README.md
@@ -27,16 +27,16 @@ Both given muted styles to indicate a lack of interactivity.
 
 #### Props
 
-| Prop Name          | Type                                    | Required | Default     | Description                                                                                  |
-| ------------------ | --------------------------------------- | -------- | ----------- | -------------------------------------------------------------------------------------------- |
-| `[htmlAttributes]` | `React.AllHTMLAttributes<InputElement>` | No       | `undefined` | Any valid HTML attribute for an input element.                                               |
-| `className`        | `string`                                | No       | `undefined` | Additional class names to apply to the input element.                                        |
-| `id`               | `string`                                | Yes      | `undefined` | Id attribute assigned to the input element. Required to create an accessible label.          |
-| `label`            | `string`                                | No       | `undefined` | The accessble label to be associatied with the input. Not required but strongly recommended. |
-| `hint`             | `string`                                | No       | `undefined` | Smaller hint text to go under the label.                                                     |
-| `feedback`         | `string`                                | No       | `undefined` | Custom informative feedback about the input requirements under the element.                  |
-| `error`            | `string \| boolean`                     | No       | `undefined` | Custom or default error feedback under the element.                                          |
-| `clean`            | `string \| boolean`                     | No       | `undefined` | Custom or default success feedback under the element.                                        |
+| Prop Name          | Type                                    | Required | Default     | Description                                                                                 |
+| ------------------ | --------------------------------------- | -------- | ----------- | ------------------------------------------------------------------------------------------- |
+| `[htmlAttributes]` | `React.AllHTMLAttributes<InputElement>` | No       | `undefined` | Any valid HTML attribute for an input element.                                              |
+| `className`        | `string`                                | No       | `undefined` | Additional class names to apply to the input element.                                       |
+| `id`               | `string`                                | Yes      | `undefined` | Id attribute assigned to the input element. Required to create an accessible label.         |
+| `label`            | `React.ReactNode`                       | No       | `undefined` | The accessble label to be associated with the input. Not required but strongly recommended. |
+| `hint`             | `React.ReactNode`                       | No       | `undefined` | Smaller hint text to go under the label.                                                    |
+| `feedback`         | `React.ReactNode`                       | No       | `undefined` | Custom informative feedback about the input requirements under the element.                 |
+| `error`            | `React.ReactNode \| boolean`            | No       | `undefined` | Custom or default error feedback under the element.                                         |
+| `clean`            | `React.ReactNode \| boolean`            | No       | `undefined` | Custom or default success feedback under the element.                                       |
 
 #### Example
 

--- a/src/lib/components/LoadingSpinner/LoadingSpinner.css
+++ b/src/lib/components/LoadingSpinner/LoadingSpinner.css
@@ -1,17 +1,29 @@
 .pk-loading-spinner {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  place-items: center;
+  margin: 0.25rem;
+  display: inline-block;
+  vertical-align: middle;
+  margin-top: calc(1ex - 1cap);
 }
 
-.pk-loading-spinner::after {
+.pk-loading-spinner-backdrop {
+  display: grid;
+  place-items: center;
+  backdrop-filter: blur(1px);
+  -webkit-backdrop-filter: blur(1px);
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  margin-top: 0;
+}
+
+.pk-loading-spinner-backdrop::after {
   content: "";
   position: absolute;
   height: 100%;
   width: 100%;
   background-color: currentColor;
-  opacity: 0.5;
+  opacity: 0.4;
+  z-index: -1;
 }
 
 .pk-loading-spinner-inner {

--- a/src/lib/components/LoadingSpinner/LoadingSpinner.model.ts
+++ b/src/lib/components/LoadingSpinner/LoadingSpinner.model.ts
@@ -2,4 +2,5 @@ import { AllHtmlAttributes } from "../../core-types"
 
 export type TLoadingSpinnerProps = AllHtmlAttributes & {
   fit?: "xs" | "sm" | "md" | "lg" | "xl"
+  backdrop?: boolean
 }

--- a/src/lib/components/LoadingSpinner/LoadingSpinner.spec.tsx
+++ b/src/lib/components/LoadingSpinner/LoadingSpinner.spec.tsx
@@ -6,10 +6,36 @@ import { LoadingSpinner } from "./LoadingSpinner"
 import { sizeMap, spinnerDotCountMap, spinnerDotSizeMap } from "./utils/spinner-dimensions"
 
 describe("LoadingSpinner", () => {
-  it("should render the component", () => {
-    render(<LoadingSpinner />)
-    const loadingSpinner = screen.getByRole("progressbar")
-    expect(loadingSpinner).toBeInTheDocument()
+  describe("with default props", () => {
+    beforeEach(() => {
+      render(<LoadingSpinner />)
+    })
+
+    it("should render the component", () => {
+      const loadingSpinner = screen.getByRole("progressbar")
+      expect(loadingSpinner).toBeInTheDocument()
+    })
+
+    it("should apply the backdrop class", () => {
+      const loadingSpinner = screen.getByRole("progressbar")
+      expect(loadingSpinner).toHaveClass("pk-loading-spinner-backdrop")
+    })
+
+    it("should default to medium size", () => {
+      const dots = screen.getAllByTestId("pk-loading-spinner-dot")
+      expect(dots).toHaveLength(spinnerDotCountMap.md)
+    })
+  })
+
+  describe("with no backdrop", () => {
+    beforeEach(() => {
+      render(<LoadingSpinner backdrop={false} />)
+    })
+
+    it("should not apply the backdrop class", () => {
+      const loadingSpinner = screen.getByRole("progressbar")
+      expect(loadingSpinner).not.toHaveClass("pk-loading-spinner-backdrop")
+    })
   })
 
   for (const size of ["xs", "sm", "md", "lg", "xl"] as const) {

--- a/src/lib/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/lib/components/LoadingSpinner/LoadingSpinner.tsx
@@ -5,14 +5,18 @@ import { circlePointPosition } from "./utils/geometry"
 import "./LoadingSpinner.css"
 
 export function LoadingSpinner(props: TLoadingSpinnerProps) {
-  const { fit = "md", ...rest } = props
+  const { fit = "md", backdrop = true, ...rest } = props
 
   const dots = useMemo(() => Array.from({ length: spinnerDotCountMap[fit] }, (_, i) => i), [fit])
   const height = useMemo(() => sizeMap[fit], [fit])
   const dotSize = useMemo(() => spinnerDotSizeMap[fit], [fit])
 
+  const classNames = useMemo(() => {
+    return `pk-loading-spinner ${backdrop ? "pk-loading-spinner-backdrop" : ""}`
+  }, [backdrop])
+
   return (
-    <div className="pk-loading-spinner" role="progressbar">
+    <div className={classNames} role="progressbar">
       <div className="pk-loading-spinner-inner" style={{ height: `${height}px` }}>
         {dots.map(i => {
           const { x, y } = circlePointPosition(height, dots.length, i)

--- a/src/lib/components/LoadingSpinner/utils/spinner-dimensions.ts
+++ b/src/lib/components/LoadingSpinner/utils/spinner-dimensions.ts
@@ -11,7 +11,7 @@ export const sizeMap: TSpinnerMap = {
   sm: 16,
   md: 20,
   lg: 28,
-  xl: 36,
+  xl: 64,
 }
 
 /**
@@ -34,5 +34,5 @@ export const spinnerDotCountMap: TSpinnerMap = {
   sm: 6,
   md: 8,
   lg: 10,
-  xl: 14,
+  xl: 12,
 }


### PR DESCRIPTION
Style improvements to Demo website

- Standardized layout
- Include `PropsTable` sections
- Better `LoadingSpinner` examples

Updates to the library
- `Input` component takes `ReactNode` type for text based props
- `LoadingSpinner` gets new `backdrop` prop
   - Setting to `false` makes the spinner behave as an inline-block element with no overlay
- Better test coverage
- Removal of redundant props in readmes