### PR TITLE
Allow all compatible react versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     }
   },
   "peerDependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react": ">=16.8.0 <20",
+    "react-dom": ">=16.8.0 <20"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",


### PR DESCRIPTION
Relax the react and react-dom peer dependency version to allow 16.8 - 19.x